### PR TITLE
docs: `about-us` link shows `Page Not Found` for a fraction of a second

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Celest](https://celest.dev) is the Flutter cloud platform. We enable Flutter and Dart developers to declaratively define their backend infrastructure in Dart.
 
-You can join our waitlist at [celest.dev](https://celest.dev). To learn more about our values and how we operate, visit our [about us](https://celest.dev/about-us/) page.
+You can join our waitlist at [celest.dev](https://celest.dev). To learn more about our values and how we operate, visit our [about us](https://celest.dev/about-us) page.
 
 ## Connect with us
 


### PR DESCRIPTION
Apparently the website shows a Page Not Found for less than a millisecond to then show the content, removing the last / from the URL seems to be the "correct" url for that page.