### PR TITLE
chore: Rename Celest project package

### DIFF
--- a/packages/celest/example/celest/lib/client.dart
+++ b/packages/celest/example/celest/lib/client.dart
@@ -11,6 +11,9 @@ import 'package:http/http.dart' as http;
 
 import 'src/client/functions.dart';
 
+export 'exceptions.dart';
+export 'models.dart';
+
 final Celest celest = Celest();
 
 class Celest {

--- a/packages/celest/example/celest/lib/exceptions.dart
+++ b/packages/celest/example/celest/lib/exceptions.dart
@@ -1,0 +1,2 @@
+// By convention, any custom exception types thrown by an API must be defined
+// in this file or exported from this file.

--- a/packages/celest/example/celest/lib/models.dart
+++ b/packages/celest/example/celest/lib/models.dart
@@ -1,0 +1,2 @@
+// By convention, any custom types used within an API request/response must be
+// defined in this file or exported from this file.

--- a/packages/celest/example/celest/pubspec.yaml
+++ b/packages/celest/example/celest/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example_app_celest
+name: celest_backend
 description: The Celest backend for example_app.
 publish_to: none
 

--- a/packages/celest/example/lib/main.dart
+++ b/packages/celest/example/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:example_app_celest/client.dart';
+import 'package:celest_backend/client.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/packages/celest/example/pubspec.yaml
+++ b/packages/celest/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=3.2.5 <4.0.0'
 
 dependencies:
-  example_app_celest:
+  celest_backend:
     path: celest/
   flutter:
     sdk: flutter


### PR DESCRIPTION
Renames Celest project package to `celest_backend` by convention.