### PR TITLE
chore(core): Improve SerializationException message

### DIFF
--- a/packages/celest_core/CHANGELOG.md
+++ b/packages/celest_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.1-wip
 
 - Update README
+- Improve error message of `SerializationException`
 
 ## 0.1.0
 

--- a/packages/celest_core/lib/src/serialization/serializer.dart
+++ b/packages/celest_core/lib/src/serialization/serializer.dart
@@ -109,7 +109,8 @@ final class _Serializers extends Serializers {
     final serializer = get<Dart>();
     if (serializer == null) {
       throw SerializationException(
-        'No serializer found for $Dart. Did you forget to put() it?',
+        'No serializer found for $Dart. Did you forget to call `celest.init()` '
+        "at the start of your Flutter app's `main` function?",
       );
     }
     return serializer;


### PR DESCRIPTION
While this exception can be thrown on the client or server, it is only thrown on the client by fault of the user. And there is only one reason why this would be the case.