### PR TITLE
chore(core): Make `SerializationException` implement `BadRequestException`

### DIFF
--- a/packages/celest_core/CHANGELOG.md
+++ b/packages/celest_core/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.2.0-dev
 
+- Make `SerializationException` implement `BadRequestException`
+
 ## 0.1.1
 
 - Update README

--- a/packages/celest_core/lib/src/exception/cloud_exception.dart
+++ b/packages/celest_core/lib/src/exception/cloud_exception.dart
@@ -7,7 +7,7 @@ sealed class CloudException implements CelestException {}
 /// An exception thrown by a Cloud Function when a request contains invalid
 /// data or otherwise lead to a recoverable exception.
 /// {@endtemplate}
-final class BadRequestException implements CloudException {
+class BadRequestException implements CloudException {
   /// Creates a [BadRequestException] with the given [message].
   ///
   /// {@macro celest_core_exception_bad_request_exception}

--- a/packages/celest_core/lib/src/exception/serialization_exception.dart
+++ b/packages/celest_core/lib/src/exception/serialization_exception.dart
@@ -7,7 +7,7 @@ import 'package:celest_core/celest_core.dart';
 /// deserialize a value.
 /// {@endtemplate}
 final class SerializationException extends FormatException
-    implements CelestException {
+    implements BadRequestException, CelestException {
   /// Creates a [SerializationException] with the given [message].
   ///
   /// {@macro celest_core_exceptions_serialization_exception}


### PR DESCRIPTION
When thrown on the server, a serialization exception means that the server received bad data from the client.