### PR TITLE
fix(ios): Secure storage query

### DIFF
--- a/packages/celest_core/lib/src/storage/secure/secure_storage.darwin.dart
+++ b/packages/celest_core/lib/src/storage/secure/secure_storage.darwin.dart
@@ -81,7 +81,6 @@ final class SecureStoragePlatformDarwin extends SecureStoragePlatform {
     final query = {
       ..._baseQuery(arena),
       kSecAttrAccount: key.toCFString(arena),
-      kSecMatchLimit: kSecMatchLimitOne,
     };
     final gets = SecItemCopyMatching(query.toCFDictionary(arena), nullptr);
     if (gets != errSecSuccess && gets != errSecItemNotFound) {
@@ -116,7 +115,6 @@ final class SecureStoragePlatformDarwin extends SecureStoragePlatform {
     final query = {
       ..._baseQuery(arena),
       kSecAttrAccount: key.toCFString(arena),
-      kSecMatchLimit: kSecMatchLimitOne,
     };
     try {
       _check(


### PR DESCRIPTION
Removes `kSecMatchLimit` from write and delete queries which was accidentally added.