### PR TITLE
chore(auth): Clean up

### DIFF
--- a/packages/celest/pubspec.yaml
+++ b/packages/celest/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   async: ^2.11.0
+  celest_auth: ^0.3.0
   celest_core: ^0.2.0
   chunked_stream: ^1.4.2
   meta: ^1.9.0

--- a/packages/celest/pubspec_overrides.yaml
+++ b/packages/celest/pubspec_overrides.yaml
@@ -1,0 +1,9 @@
+dependency_overrides:
+  cedar:
+    path: ../cedar
+  celest_auth:
+    path: ../celest_auth
+  celest_core:
+    path: ../celest_core
+  corks:
+    path: ../corks

--- a/packages/celest_auth/example/celest/pubspec.yaml
+++ b/packages/celest_auth/example/celest/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
 
 dependencies:
   celest: ^0.2.0
-  celest_auth: any
   celest_core: ^0.2.0
   http: ">=0.13.0 <2.0.0"
 

--- a/packages/celest_auth/example/lib/main.dart
+++ b/packages/celest_auth/example/lib/main.dart
@@ -20,7 +20,7 @@ class _MainAppState extends State<MainApp> {
 
   Future<void> signUp() async {
     try {
-      await celest.auth.email.signIn(email: _emailController.text);
+      await celest.auth.email.authenticate(email: _emailController.text);
       _emailController.clear();
     } on Exception catch (e, st) {
       debugPrint('Error: $e');
@@ -92,7 +92,7 @@ class _MainAppState extends State<MainApp> {
                           ),
                           const SizedBox(height: 16),
                           TextButton(
-                            onPressed: () => state.verifyOtp(
+                            onPressed: () => state.verify(
                               _otpController.text,
                             ),
                             child: const Text('Verify OTP'),

--- a/packages/celest_auth/lib/src/flows/email_flow.dart
+++ b/packages/celest_auth/lib/src/flows/email_flow.dart
@@ -13,12 +13,12 @@ extension type Email(AuthImpl _hub) {
   ///
   /// OTP codes are valid for 15 minutes and can be resent after 60 seconds
   /// by calling `resend` on the returned state object.
-  Future<EmailNeedsVerification> signIn({
+  Future<EmailNeedsVerification> authenticate({
     required String email,
   }) async {
     final flowController = await _hub.requestFlow();
     final flow = EmailFlow._(_hub, flowController);
-    return flow._signIn(email: email);
+    return flow._authenticate(email: email);
   }
 }
 
@@ -30,7 +30,7 @@ final class EmailFlow implements AuthFlow {
 
   EmailProtocol get _protocol => _hub.protocol.email;
 
-  Future<EmailNeedsVerification> _signIn({
+  Future<EmailNeedsVerification> _authenticate({
     required String email,
   }) {
     return _flowController.capture(() async {
@@ -80,8 +80,8 @@ final class _EmailNeedsVerification extends EmailNeedsVerification {
   }
 
   @override
-  Future<User> verifyOtp(String otp) async {
-    final authenticated = await _flow._verifyOtp(email: email, otp: otp);
+  Future<User> verify(String otpCode) async {
+    final authenticated = await _flow._verifyOtp(email: email, otp: otpCode);
     return authenticated.user;
   }
 

--- a/packages/celest_auth/lib/src/state/auth_state.dart
+++ b/packages/celest_auth/lib/src/state/auth_state.dart
@@ -28,7 +28,7 @@ abstract class EmailNeedsVerification extends AuthFlowInProgress {
   final String email;
 
   Future<void> resend();
-  Future<User> verifyOtp(String otp);
+  Future<User> verify(String otpCode);
 }
 
 /// The [user] is authenticated and their identity has been verified.

--- a/packages/celest_core/lib/src/storage/secure/secure_storage.darwin.dart
+++ b/packages/celest_core/lib/src/storage/secure/secure_storage.darwin.dart
@@ -81,7 +81,6 @@ final class SecureStoragePlatformDarwin extends SecureStoragePlatform {
     final query = {
       ..._baseQuery(arena),
       kSecAttrAccount: key.toCFString(arena),
-      kSecMatchLimit: kSecMatchLimitOne,
     };
     final gets = SecItemCopyMatching(query.toCFDictionary(arena), nullptr);
     if (gets != errSecSuccess && gets != errSecItemNotFound) {
@@ -116,7 +115,6 @@ final class SecureStoragePlatformDarwin extends SecureStoragePlatform {
     final query = {
       ..._baseQuery(arena),
       kSecAttrAccount: key.toCFString(arena),
-      kSecMatchLimit: kSecMatchLimitOne,
     };
     try {
       _check(


### PR DESCRIPTION
- Rename `email.signIn` to `email.authenticate` to better align with functionality.
- Add `celest_auth` as a dependency of `celest` so that it can be imported easily in clientgen.