### PR TITLE
fix: Allow `null` for `@httpQuery` and `@httpHeader` parameters

### DIFF
--- a/packages/celest/CHANGELOG.md
+++ b/packages/celest/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3-wip
+
+- fix: Allow `null` for `@httpQuery` and `@httpHeader` parameters, defaulting to the parameter name.
+
 ## 0.4.2
 
 - feat: Add support for event streaming via SSE/WebSockets

--- a/packages/celest/lib/src/functions/http/http_header.dart
+++ b/packages/celest/lib/src/functions/http/http_header.dart
@@ -6,8 +6,10 @@ import 'package:meta/meta_meta.dart';
 @Target({TargetKind.parameter})
 final class httpHeader {
   /// {@macro celest.http.http_header}
-  const httpHeader(this.name);
+  const httpHeader([this.name]);
 
   /// The name of the HTTP header.
-  final String name;
+  ///
+  /// If `null`, the name of the parameter will be used.
+  final String? name;
 }

--- a/packages/celest/lib/src/functions/http/http_query.dart
+++ b/packages/celest/lib/src/functions/http/http_query.dart
@@ -6,8 +6,10 @@ import 'package:meta/meta_meta.dart';
 @Target({TargetKind.parameter})
 final class httpQuery {
   /// {@macro celest.functions.http.http_query}
-  const httpQuery(this.name);
+  const httpQuery([this.name]);
 
   /// The name of the HTTP query parameter.
-  final String name;
+  ///
+  /// If `null`, the name of the parameter will be used.
+  final String? name;
 }

--- a/packages/celest/pubspec.yaml
+++ b/packages/celest/pubspec.yaml
@@ -1,6 +1,6 @@
 name: celest
 description: The Flutter cloud platform. Celest enables you to build your entire backend in Dart.
-version: 0.4.2
+version: 0.4.3-wip
 homepage: https://celest.dev
 repository: https://github.com/celest-dev/celest/tree/main/packages/celest
 


### PR DESCRIPTION
Default to the parameter name for unspecified httpQuery/httpHeader names.