### PR TITLE
ci(cloud_auth): Fix test environment

### DIFF
--- a/.github/workflows/celest_cloud_auth.yaml
+++ b/.github/workflows/celest_cloud_auth.yaml
@@ -33,7 +33,7 @@ jobs:
         working-directory: services/celest_cloud_auth
         run: dart format --set-exit-if-changed .
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 15
     steps:
       - name: Git Checkout


### PR DESCRIPTION
Use macOS for running tests since it has a newer version of SQLite pre-installed