### PR TITLE
chore(lints): Update Celest lints for Dart 3.7

### DIFF
--- a/packages/celest_lints/CHANGELOG.md
+++ b/packages/celest_lints/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.0
+
+- Bump min Dart SDK version to 3.7.
+- Update `lints` to `^5.0.0`.
+- Update `flutter_lints` to `^5.0.0`.
+- Remove `require_trailing_commas` rule (conflicts with Dart 3.7 formatting).
+
 ## 1.0.0
 
 - Initial version.

--- a/packages/celest_lints/lib/app.yaml
+++ b/packages/celest_lints/lib/app.yaml
@@ -28,7 +28,6 @@ linter:
     - prefer_int_literals                              # To improve code readability.
     - prefer_null_aware_method_calls                   # To improve code readability.
     - prefer_single_quotes                             # To encourage consistent styling.
-    - require_trailing_commas                          # To improve code readability.
     - secure_pubspec_urls                              # To improve security posture.
     - sized_box_shrink_expand                          # To improve code readability.
     - sort_constructors_first                          # To provide a consistent style for classes.

--- a/packages/celest_lints/lib/library.yaml
+++ b/packages/celest_lints/lib/library.yaml
@@ -56,7 +56,6 @@ linter:
     - prefer_null_aware_method_calls                   # To improve code readability.
     - prefer_single_quotes                             # To encourage consistent styling.
     - public_member_api_docs                           # To provide users with ample context and explanation.
-    - require_trailing_commas                          # To improve code readability.
     - sort_constructors_first                          # To provide a consistent style for classes.
     - sort_unnamed_constructors_first                  # To provide organization and quick exploration.
     - sort_pub_dependencies                            # To simplify searching a large list.

--- a/packages/celest_lints/pubspec.yaml
+++ b/packages/celest_lints/pubspec.yaml
@@ -1,12 +1,12 @@
 name: celest_lints
 description: The lint rules used in developing Celest packages and plugins.
-version: 1.0.0
+version: 1.1.0
 homepage: https://celest.dev
 repository: https://github.com/celest-dev/celest/tree/main/packages/celest_lints
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.7.0
 
 dependencies:
-  flutter_lints: ^4.0.0
-  lints: ^4.0.0
+  flutter_lints: ^5.0.0
+  lints: ^5.0.0


### PR DESCRIPTION
- Bump min Dart SDK version to 3.7.
- Update `lints` to `^5.0.0`.
- Update `flutter_lints` to `^5.0.0`.
- Remove `require_trailing_commas` rule (conflicts with Dart 3.7 formatting).