### PR TITLE
chore(cli): Update goldens

### DIFF
--- a/.github/workflows/celest_cli.yaml
+++ b/.github/workflows/celest_cli.yaml
@@ -26,7 +26,7 @@ jobs:
           - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 30 # Windows is really slow
     steps:
       - name: Git Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
@@ -36,7 +36,7 @@ jobs:
           cache: true
           # Because many golden tests encode the precise Dart/Flutter SDKs used to generate
           # them, these values must be consistently used when running tests locally and in CI.
-          flutter-version: 3.29.1
+          flutter-version: 3.29.2
       - name: Setup Libsecret
         if: runner.os == 'Linux'
         run: tool/setup-ci.sh
@@ -47,6 +47,5 @@ jobs:
         working-directory: apps/cli
         run: dart test -x e2e --fail-fast -j 1
       - name: Test (Fixtures)
-        if: runner.os == 'macOS' # TODO: Goldens differ on other OSes
         working-directory: apps/cli
         run: dart test fixtures/fixtures_test.dart --fail-fast -j 1

--- a/apps/cli/fixtures/standalone/api/client/lib/api_client.dart
+++ b/apps/cli/fixtures/standalone/api/client/lib/api_client.dart
@@ -18,88 +18,88 @@ import 'package:native_storage/native_storage.dart'
 export 'package:celest_backend/exceptions/demo.dart' show BadNameException;
 export 'package:celest_backend/exceptions/exceptions.dart'
     show
-        CustomException,
-        CustomExceptionToFromJson,
         CustomError,
         CustomErrorToFromJson,
-        CustomErrorWithStackTrace;
+        CustomErrorWithStackTrace,
+        CustomException,
+        CustomExceptionToFromJson;
 export 'package:celest_backend/exceptions/overrides.dart'
     show OverriddenException;
 export 'package:celest_backend/models/classes.dart'
     show
+        DefaultValues,
         Empty,
         Fields,
-        NamedFields,
-        MixedFields,
-        DefaultValues,
-        NestedClass,
-        OnlyFromJson,
-        OnlyToJson,
-        OnlyToJsonWithDefaults,
         FromJsonAndToJson,
+        FromJsonStatic,
+        MixedFields,
+        NamedFields,
+        NestedClass,
+        NonMapFromAndToJson,
         NonMapToJson,
         NonMapToJsonWithDefaults,
-        NonMapFromAndToJson,
-        FromJsonStatic;
+        OnlyFromJson,
+        OnlyToJson,
+        OnlyToJsonWithDefaults;
 export 'package:celest_backend/models/cycles.dart'
     show Node, Parent, SelfReferencing;
 export 'package:celest_backend/models/demo.dart' show Person;
 export 'package:celest_backend/models/exceptions.dart'
-    show SupportedExceptionType, SupportedErrorType;
+    show SupportedErrorType, SupportedExceptionType;
 export 'package:celest_backend/models/extension_types.dart'
     show
-        StringX,
-        StringXImpl,
-        StringXToFromJson,
-        StringXToJson,
-        StringXToJsonImpl,
-        StringXFromJson,
-        StringXFromJsonImpl,
-        StringXFromJsonStatic,
-        StringXPrivateField,
-        StringXPrivateFieldImpl,
-        StringXPrivateCtor,
-        StringXPrivateCtorImpl,
-        Value,
-        ValueX,
-        ValueXImpl,
-        ValueXToFromJson,
-        ValueXToJson,
-        ValueXToJsonImpl,
-        ValueXFromJson,
-        ValueXFromJsonImpl,
-        ValueXFromJsonStatic,
         Color,
         ColorX,
+        ColorXFromJson,
+        ColorXFromJsonImpl,
+        ColorXFromJsonStatic,
         ColorXImpl,
         ColorXToFromJson,
         ColorXToJson,
         ColorXToJsonImpl,
-        ColorXFromJson,
-        ColorXFromJsonImpl,
-        ColorXFromJsonStatic;
+        StringX,
+        StringXFromJson,
+        StringXFromJsonImpl,
+        StringXFromJsonStatic,
+        StringXImpl,
+        StringXPrivateCtor,
+        StringXPrivateCtorImpl,
+        StringXPrivateField,
+        StringXPrivateFieldImpl,
+        StringXToFromJson,
+        StringXToJson,
+        StringXToJsonImpl,
+        Value,
+        ValueX,
+        ValueXFromJson,
+        ValueXFromJsonImpl,
+        ValueXFromJsonStatic,
+        ValueXImpl,
+        ValueXToFromJson,
+        ValueXToJson,
+        ValueXToJsonImpl;
 export 'package:celest_backend/models/generic_wrappers.dart'
     show GenericWrappers;
 export 'package:celest_backend/models/metadata.dart'
-    show Exportable, Serializable, LiteralEnum;
+    show Exportable, LiteralEnum, Serializable;
 export 'package:celest_backend/models/overrides.dart'
-    show NestedGrandparent, NestedParent, NestedChild;
+    show NestedChild, NestedGrandparent, NestedParent;
 export 'package:celest_backend/models/parameter_types.dart'
-    show MyEnum, SimpleStruct, ComplexStruct, SimpleClass, ComplexClass;
+    show ComplexClass, ComplexStruct, MyEnum, SimpleClass, SimpleStruct;
 export 'package:celest_backend/models/records.dart'
     show NamedFieldsRecord, Nested, NullableNested;
 export 'package:celest_backend/models/sealed_classes.dart'
     show
-        Shape,
-        Rectangle,
         Circle,
         CircleWithOverriddenCustomJson,
-        RectangleWithOverriddenCustomJson,
-        ShapeWithOverriddenCustomJson,
-        SwappedResult,
-        Result,
         OkResult,
-        OkShapeResult;
+        OkShapeResult,
+        Rectangle,
+        RectangleWithOverriddenCustomJson,
+        Result,
+        Shape,
+        ShapeWithOverriddenCustomJson,
+        SwappedResult;
 export 'package:celest_backend/models/typedefs.dart' show Portfolio;
 
 final Celest celest = Celest();

--- a/apps/cli/fixtures/standalone/api/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/api/goldens/ast.json
@@ -33716,7 +33716,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -33725,7 +33725,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/api/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/api/goldens/ast.resolved.json
@@ -3615,7 +3615,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -3624,7 +3624,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/api/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/api/goldens/celest.json
@@ -3394,19 +3394,16 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 6,
-      "build": [
-        2.0
-      ],
+      "patch": 7,
       "canonicalizedVersion": "1.0.7"
     },
     "dart": {
       "type": "DART",
       "version": {
         "major": 3,
-        "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "minor": 7,
+        "patch": 2,
+        "canonicalizedVersion": "3.7.2"
       }
     },
     "flutter": {
@@ -3414,8 +3411,8 @@
       "version": {
         "major": 3,
         "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "patch": 2,
+        "canonicalizedVersion": "3.29.2"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/auth/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/ast.json
@@ -2060,7 +2060,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "flutter",
@@ -2069,7 +2069,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/auth/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/ast.resolved.json
@@ -405,7 +405,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "flutter",
@@ -414,7 +414,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/auth/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/celest.json
@@ -426,19 +426,16 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 6,
-      "build": [
-        2.0
-      ],
+      "patch": 7,
       "canonicalizedVersion": "1.0.7"
     },
     "dart": {
       "type": "DART",
       "version": {
         "major": 3,
-        "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "minor": 7,
+        "patch": 2,
+        "canonicalizedVersion": "3.7.2"
       }
     },
     "flutter": {
@@ -446,8 +443,8 @@
       "version": {
         "major": 3,
         "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "patch": 2,
+        "canonicalizedVersion": "3.29.2"
       }
     },
     "targetSdk": "FLUTTER",

--- a/apps/cli/fixtures/standalone/data/client/lib/data_client.dart
+++ b/apps/cli/fixtures/standalone/data/client/lib/data_client.dart
@@ -16,7 +16,7 @@ import 'package:native_storage/native_storage.dart'
     as _$native_storage_native_storage;
 
 export 'package:celest_backend/src/database/task_database.dart'
-    show Task, Priority;
+    show Priority, Task;
 
 final Celest celest = Celest();
 

--- a/apps/cli/fixtures/standalone/data/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/data/goldens/ast.json
@@ -628,7 +628,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -637,7 +637,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/data/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/data/goldens/ast.resolved.json
@@ -58,7 +58,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -67,7 +67,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/data/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/data/goldens/celest.json
@@ -57,19 +57,16 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 6,
-      "build": [
-        2.0
-      ],
+      "patch": 7,
       "canonicalizedVersion": "1.0.7"
     },
     "dart": {
       "type": "DART",
       "version": {
         "major": 3,
-        "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "minor": 7,
+        "patch": 2,
+        "canonicalizedVersion": "3.7.2"
       }
     },
     "flutter": {
@@ -77,8 +74,8 @@
       "version": {
         "major": 3,
         "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "patch": 2,
+        "canonicalizedVersion": "3.29.2"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/env_vars/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/ast.json
@@ -830,7 +830,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -839,7 +839,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/env_vars/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/ast.resolved.json
@@ -94,7 +94,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -103,7 +103,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/env_vars/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/celest.json
@@ -95,19 +95,16 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 6,
-      "build": [
-        2.0
-      ],
+      "patch": 7,
       "canonicalizedVersion": "1.0.7"
     },
     "dart": {
       "type": "DART",
       "version": {
         "major": 3,
-        "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "minor": 7,
+        "patch": 2,
+        "canonicalizedVersion": "3.7.2"
       }
     },
     "flutter": {
@@ -115,8 +112,8 @@
       "version": {
         "major": 3,
         "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "patch": 2,
+        "canonicalizedVersion": "3.29.2"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/exceptions/client/lib/exceptions_client.dart
+++ b/apps/cli/fixtures/standalone/exceptions/client/lib/exceptions_client.dart
@@ -16,7 +16,7 @@ import 'package:native_storage/native_storage.dart'
     as _$native_storage_native_storage;
 
 export 'package:celest_backend/exceptions/exceptions.dart'
-    show BaseException, CustomException, BaseError, CustomError;
+    show BaseError, BaseException, CustomError, CustomException;
 
 final Celest celest = Celest();
 

--- a/apps/cli/fixtures/standalone/exceptions/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/ast.json
@@ -1316,7 +1316,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -1325,7 +1325,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/exceptions/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/ast.resolved.json
@@ -190,7 +190,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -199,7 +199,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/exceptions/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/celest.json
@@ -179,19 +179,16 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 6,
-      "build": [
-        2.0
-      ],
+      "patch": 7,
       "canonicalizedVersion": "1.0.7"
     },
     "dart": {
       "type": "DART",
       "version": {
         "major": 3,
-        "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "minor": 7,
+        "patch": 2,
+        "canonicalizedVersion": "3.7.2"
       }
     },
     "flutter": {
@@ -199,8 +196,8 @@
       "version": {
         "major": 3,
         "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "patch": 2,
+        "canonicalizedVersion": "3.29.2"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/flutter/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/ast.json
@@ -1108,7 +1108,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "flutter",
@@ -1117,7 +1117,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/flutter/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/ast.resolved.json
@@ -89,7 +89,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "flutter",
@@ -98,7 +98,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/flutter/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/celest.json
@@ -84,19 +84,16 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 6,
-      "build": [
-        2.0
-      ],
+      "patch": 7,
       "canonicalizedVersion": "1.0.7"
     },
     "dart": {
       "type": "DART",
       "version": {
         "major": 3,
-        "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "minor": 7,
+        "patch": 2,
+        "canonicalizedVersion": "3.7.2"
       }
     },
     "flutter": {
@@ -104,8 +101,8 @@
       "version": {
         "major": 3,
         "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "patch": 2,
+        "canonicalizedVersion": "3.29.2"
       }
     },
     "targetSdk": "FLUTTER",

--- a/apps/cli/fixtures/standalone/http/client/lib/api_client.dart
+++ b/apps/cli/fixtures/standalone/http/client/lib/api_client.dart
@@ -17,14 +17,14 @@ import 'package:native_storage/native_storage.dart'
 
 export 'package:celest_backend/exceptions/http_errors.dart'
     show
+        AnotherNotFoundException,
+        BadGatewayError,
         CustomBadRequestException,
         ForbiddenException,
-        NotFoundException,
-        AnotherNotFoundException,
-        BadGatewayError;
+        NotFoundException;
 export 'package:celest_backend/models/http_errors.dart' show ExceptionType;
 export 'package:celest_backend/models/http_header_query.dart'
-    show HttpQueryParams, HttpHeaderParams;
+    show HttpHeaderParams, HttpQueryParams;
 
 final Celest celest = Celest();
 

--- a/apps/cli/fixtures/standalone/http/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/http/goldens/ast.json
@@ -4936,7 +4936,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -4945,7 +4945,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/http/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/http/goldens/ast.resolved.json
@@ -254,7 +254,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -263,7 +263,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/http/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/http/goldens/celest.json
@@ -240,19 +240,16 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 6,
-      "build": [
-        2.0
-      ],
+      "patch": 7,
       "canonicalizedVersion": "1.0.7"
     },
     "dart": {
       "type": "DART",
       "version": {
         "major": 3,
-        "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "minor": 7,
+        "patch": 2,
+        "canonicalizedVersion": "3.7.2"
       }
     },
     "flutter": {
@@ -260,8 +257,8 @@
       "version": {
         "major": 3,
         "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "patch": 2,
+        "canonicalizedVersion": "3.29.2"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/marcelo/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/ast.json
@@ -1620,7 +1620,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -1629,7 +1629,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/marcelo/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/ast.resolved.json
@@ -233,7 +233,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -242,7 +242,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/marcelo/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/celest.json
@@ -219,19 +219,16 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 6,
-      "build": [
-        2.0
-      ],
+      "patch": 7,
       "canonicalizedVersion": "1.0.7"
     },
     "dart": {
       "type": "DART",
       "version": {
         "major": 3,
-        "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "minor": 7,
+        "patch": 2,
+        "canonicalizedVersion": "3.7.2"
       }
     },
     "flutter": {
@@ -239,8 +236,8 @@
       "version": {
         "major": 3,
         "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "patch": 2,
+        "canonicalizedVersion": "3.29.2"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/simple/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/simple/goldens/ast.json
@@ -14,7 +14,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -23,7 +23,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/simple/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/simple/goldens/ast.resolved.json
@@ -14,7 +14,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -23,7 +23,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/streaming/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/ast.json
@@ -528,7 +528,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -537,7 +537,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/streaming/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/ast.resolved.json
@@ -74,7 +74,7 @@
     "celest": "1.0.7",
     "dart": {
       "type": "dart",
-      "version": "3.29.1",
+      "version": "3.7.2",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -83,7 +83,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.29.1",
+      "version": "3.29.2",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/streaming/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/celest.json
@@ -64,19 +64,16 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 6,
-      "build": [
-        2.0
-      ],
+      "patch": 7,
       "canonicalizedVersion": "1.0.7"
     },
     "dart": {
       "type": "DART",
       "version": {
         "major": 3,
-        "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "minor": 7,
+        "patch": 2,
+        "canonicalizedVersion": "3.7.2"
       }
     },
     "flutter": {
@@ -84,8 +81,8 @@
       "version": {
         "major": 3,
         "minor": 29,
-        "patch": 1,
-        "canonicalizedVersion": "3.29.1"
+        "patch": 2,
+        "canonicalizedVersion": "3.29.2"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/lib/codegen/allocator.dart
+++ b/apps/cli/lib/codegen/allocator.dart
@@ -40,8 +40,7 @@ final class CelestAllocator implements Allocator {
     @visibleForTesting String? clientPackageName,
     @visibleForTesting ProjectPaths? projectPaths,
   }) : packageName = packageName ?? celestProject.pubspec.name,
-       clientPackageName =
-           clientPackageName ?? celestProject.clientPubspec.name,
+       clientPackageName = clientPackageName ?? celestProject.clientPackageName,
        projectPaths = projectPaths ?? celestProject.projectPaths;
 
   static const _doNotPrefix = ['dart:core', 'package:meta/meta.dart'];

--- a/apps/cli/lib/codegen/client/client_generator.dart
+++ b/apps/cli/lib/codegen/client/client_generator.dart
@@ -120,7 +120,7 @@ final class ClientGenerator {
                 .map(
                   (symbols) => Directive.export(
                     symbols.key,
-                    show: symbols.value.map((s) => s.symbol!).toSet().toList(),
+                    show: symbols.value.map((s) => s.symbol!).toSet().sorted(),
                   ),
                 ),
           ])

--- a/apps/cli/lib/compiler/api/local_api_runner.dart
+++ b/apps/cli/lib/compiler/api/local_api_runner.dart
@@ -94,18 +94,18 @@ final class LocalApiRunner {
       }
     }
 
-    // Copy SQLite3 to the output directory on Windows.
-    if (platform.isWindows) {
-      final sqlite3Out = fileSystem
-          .directory(p.dirname(path))
-          .childFile('sqlite3.dll');
-      if (!sqlite3Out.existsSync()) {
-        final cachedSqlite3 = celestProject.config.configDir.childFile(
-          'sqlite3.dll',
-        );
-        await cachedSqlite3.copy(sqlite3Out.path);
-      }
-    }
+    // // Copy SQLite3 to the output directory on Windows.
+    // if (platform.isWindows) {
+    //   final sqlite3Out = fileSystem
+    //       .directory(p.dirname(path))
+    //       .childFile('sqlite3.dll');
+    //   if (!sqlite3Out.existsSync()) {
+    //     final cachedSqlite3 = celestProject.config.configDir.childFile(
+    //       'sqlite3.dll',
+    //     );
+    //     await cachedSqlite3.copy(sqlite3Out.path);
+    //   }
+    // }
 
     // NOTE: FE server requires file: URIs for *some* paths on Windows.
     final genKernelRes = await processManager.start(<String>[

--- a/apps/cli/lib/project/celest_project.dart
+++ b/apps/cli/lib/project/celest_project.dart
@@ -128,6 +128,9 @@ final class CelestProject {
 
   String get packageName => 'celest_backend';
 
+  /// The name of the client package.
+  String get clientPackageName => '${projectName}_client';
+
   final ProjectPaths projectPaths;
   AnalysisOptions _analysisOptions;
   AnalysisOptions get analysisOptions => _analysisOptions;

--- a/apps/cli/lib/project/project_paths.dart
+++ b/apps/cli/lib/project/project_paths.dart
@@ -95,7 +95,7 @@ final class ProjectPaths {
         pathSegments: [final package, ...final pathSegments],
       )
           when package == 'celest_backend' ||
-              package == celestProject.clientPubspec.name =>
+              package == celestProject.clientPackageName =>
         packageToFileUri(package, pathSegments),
       _ => uri,
     };
@@ -116,7 +116,7 @@ final class ProjectPaths {
       path = p.relative(path, from: clientPackageRoot).to(p.url);
       return Uri(
         scheme: 'package',
-        pathSegments: [celestProject.clientPubspec.name, ...p.url.split(path)],
+        pathSegments: [celestProject.clientPackageName, ...p.url.split(path)],
       );
     }
     return p.toUri(path);
@@ -126,7 +126,7 @@ final class ProjectPaths {
     if (package == 'celest_backend') {
       return Uri.file(p.joinAll([packageRoot, ...pathSegments]));
     }
-    if (package == celestProject.clientPubspec.name) {
+    if (package == celestProject.clientPackageName) {
       return Uri.file(p.joinAll([clientPackageRoot, ...pathSegments]));
     }
     throw ArgumentError('Cannot denormalize package $package');

--- a/apps/cli/lib/src/cli.dart
+++ b/apps/cli/lib/src/cli.dart
@@ -132,11 +132,7 @@ final class Cli {
 
     const sdkFinder = DartSdkFinder();
     final result = await sdkFinder.findSdk();
-    Sdk.current = Sdk(
-      result.sdk.path,
-      sdkType: result.sdk.type,
-      version: result.sdk.version,
-    );
+    Sdk.current = result.sdk;
   }
 
   void _setVersion(CelestCommand command) {

--- a/apps/cli/lib/src/sdk/dart_sdk.dart
+++ b/apps/cli/lib/src/sdk/dart_sdk.dart
@@ -23,15 +23,20 @@ class Sdk {
         _ => throw ArgumentError.value(sdkType, 'sdkType'),
       };
 
-  Sdk._({required this.sdkPath, this.flutterSdkRoot, Version? version})
-    : sdkType = flutterSdkRoot == null ? SdkType.dart : SdkType.flutter,
-      _version = version;
+  Sdk._({
+    required this.sdkPath,
+    this.flutterSdkRoot,
+    Version? version,
+    Version? flutterVersion,
+  }) : sdkType = flutterSdkRoot == null ? SdkType.dart : SdkType.flutter,
+       _version = version,
+       _flutterVersion = flutterVersion;
 
   Sdk.flutter(String sdkRoot, {Version? version})
     : this._(
         sdkPath: p.join(sdkRoot, 'bin', 'cache', 'dart-sdk'),
         flutterSdkRoot: sdkRoot,
-        version: version,
+        flutterVersion: version,
       );
 
   Sdk.dart(this.sdkPath, {Version? version})
@@ -46,14 +51,18 @@ class Sdk {
 
   final SdkType sdkType;
 
+  Version? _version;
+  Version? _flutterVersion;
+
   /// The SDK's semantic versioning version (x.y.z-a.b.channel).
   Version get version => _version ??= _parseVersion(sdkPath);
 
-  Version? _version;
-
   /// The Flutter SDK's semantic versioning version (x.y.z-a.b.channel).
-  late final Version? flutterVersion =
-      flutterSdkRoot == null ? null : _parseVersion(flutterSdkRoot!);
+  Version? get flutterVersion =>
+      _flutterVersion ??= switch (flutterSdkRoot) {
+        final flutterSdkRoot? => _parseVersion(flutterSdkRoot),
+        null => null,
+      };
 
   /// If using the Flutter SDK, the root directory of the Flutter SDK.
   ///


### PR DESCRIPTION
- Update goldens for Flutter 3.29.2
- Fix SDK version in `dart_sdk_finder.dart`
- Fix client pubspec generation (previously handled by V1 migrator)
- Re-enable fixture tests on all platforms