### PR TITLE
chore(cli): Clean up Dart SDK files

### DIFF
--- a/apps/cli/fixtures/fixtures_test.dart
+++ b/apps/cli/fixtures/fixtures_test.dart
@@ -22,6 +22,8 @@ import 'package:celest_cli/project/celest_project.dart';
 import 'package:celest_cli/project/project_resolver.dart';
 import 'package:celest_cli/pub/pub_action.dart';
 import 'package:celest_cli/src/context.dart';
+import 'package:celest_cli/src/sdk/dart_sdk.dart';
+import 'package:celest_cli/src/sdk/sdk_finder.dart';
 import 'package:celest_cli/src/utils/recase.dart';
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:file/file.dart';
@@ -125,12 +127,18 @@ class TestRunner {
   late CelestAnalyzer analyzer;
 
   static Future<void> _warmUp(String projectRoot) {
-    return Isolate.run(() => CelestAnalyzer.warmUp(projectRoot));
+    return Isolate.run(() async {
+      final sdkResult = await const DartSdkFinder().findSdk();
+      Sdk.current = sdkResult.sdk;
+      return CelestAnalyzer.warmUp(projectRoot);
+    });
   }
 
   void run() {
     group(testName, () {
       setUpAll(() async {
+        final sdkResult = await const DartSdkFinder().findSdk();
+        Sdk.current = sdkResult.sdk;
         await runPub(
           exe: Platform.resolvedExecutable,
           action: PubAction.upgrade,

--- a/apps/cli/lib/src/cli.dart
+++ b/apps/cli/lib/src/cli.dart
@@ -130,7 +130,10 @@ final class Cli {
       ctx.analytics.identifyUser(setOnce: {'local_iterations_mvp': true});
     }
 
-    const sdkFinder = DartSdkFinder();
+    final sdkFinder = DartSdkFinder(
+      platform: ctx.platform,
+      fileSystem: ctx.fileSystem,
+    );
     final result = await sdkFinder.findSdk();
     Sdk.current = result.sdk;
   }

--- a/apps/cli/test/env/firebase_config_value_solver_test.dart
+++ b/apps/cli/test/env/firebase_config_value_solver_test.dart
@@ -82,9 +82,9 @@ name: celest_backend
 }
 
 void main() {
-  initTests();
-
   group('FirebaseConfigValueSolver', () {
+    setUpAll(initTests);
+
     setUp(() {
       secureStorage = NativeMemoryStorage();
     });

--- a/apps/cli/test/pub/pub_cache_test.dart
+++ b/apps/cli/test/pub/pub_cache_test.dart
@@ -5,14 +5,14 @@ import 'package:test/test.dart';
 import '../common.dart';
 
 void main() {
-  initTests();
-
   group('PubCache', () {
+    setUpAll(initTests);
+
     test('finds pub cache', () {
       expect(pubCache.findCachePath(), isNotNull);
     });
 
-    test('hydrates packages', () async {
+    test('hydrates packages', timeout: Timeout.none, () async {
       final packages =
           PubCache.packagesToFix.entries
               .map((e) => '${e.key}:${e.value}')


### PR DESCRIPTION
- Remove `Sdk.load` and tests
- Migrate existing tests to `DartSdkFinder`
- Use dependency injection for `DartSdkFinder` instead of relying on global variables.