### PR TITLE
feat(cli): Add support for auxiliary commands to `celest start`

### DIFF
--- a/apps/cli/lib/src/commands/start_command.dart
+++ b/apps/cli/lib/src/commands/start_command.dart
@@ -3,6 +3,7 @@ import 'package:celest_cli/src/commands/project_init.dart';
 import 'package:celest_cli/src/commands/project_migrate.dart';
 import 'package:celest_cli/src/context.dart';
 import 'package:celest_cli/src/frontend/celest_frontend.dart';
+import 'package:celest_cli/src/frontend/child_process.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 final class StartCommand extends CelestCommand
@@ -30,10 +31,16 @@ final class StartCommand extends CelestCommand
 
     currentProgress ??= cliLogger.progress('Starting local environment');
 
+    ChildProcess? childProcess;
+    if (argResults!.rest case final command when command.isNotEmpty) {
+      childProcess = ChildProcess(command);
+    }
+
     // Start the Celest Frontend Loop
     return CelestFrontend().run(
       migrateProject: needsMigration,
       currentProgress: currentProgress,
+      childProcess: childProcess,
     );
   }
 }

--- a/apps/cli/lib/src/frontend/child_process.dart
+++ b/apps/cli/lib/src/frontend/child_process.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:celest_cli/src/context.dart';
+import 'package:celest_cli/src/utils/cli.dart';
+
+/// A process which is a child of a command like `celest start`.
+///
+/// The parent command is responsible for managing the lifecycle of the child
+/// process via this class.
+final class ChildProcess {
+  ChildProcess(this.command);
+
+  /// The command to run as a child process.
+  final List<String> command;
+  Process? _process;
+
+  /// Whether [start] has been called.
+  bool get isStarted => _process != null;
+
+  /// The process's exit code.
+  Future<int> get exitCode {
+    if (_process case final process?) {
+      return process.exitCode;
+    }
+    throw StateError('Must call start first');
+  }
+
+  /// Starts the process and streams stdout/stderr to the console.
+  Future<void> start({
+    Map<String, String>? environment,
+  }) async {
+    if (_process != null) {
+      return;
+    }
+    final process = _process = await processManager.start(
+      command,
+      environment: environment,
+    );
+
+    // Capture stdout/stderr
+    final commandName = command.first;
+    process.captureStdout(prefix: '[$commandName] ');
+    process.captureStderr(prefix: '[$commandName] ');
+
+    // TODO(dnys1): Handle stdin?
+  }
+
+  /// Kills the process with the given [signal] and waits for the process to
+  /// exit.
+  Future<void> stop([ProcessSignal signal = ProcessSignal.sigterm]) async {
+    if (_process case final process?) {
+      process.kill(signal);
+      await process.exitCode;
+    }
+    _process = null;
+  }
+}


### PR DESCRIPTION
When `--` is passed to `celest start`, run the following command after starting the local environment. For example, you can do
`celest start -- flutter test -d macos` to run tests which depend on Celest running.