### PR TITLE
fix(cli): Use prefixing in `cloud.celest.dart`

### DIFF
--- a/apps/cli/lib/src/codegen/cloud/cloud_client_generator.dart
+++ b/apps/cli/lib/src/codegen/cloud/cloud_client_generator.dart
@@ -515,7 +515,10 @@ final class CloudClientGenerator {
               );
               b.addExpression(
                 refer('context').property('put').call([
-                  refer('CelestCloudAuth').property('contextKey'),
+                  refer(
+                    'CelestCloudAuth',
+                    'package:celest_cloud_auth/celest_cloud_auth.dart',
+                  ).property('contextKey'),
                   refer('service'),
                 ]),
               );

--- a/apps/cli/lib/src/codegen/cloud_code_generator.dart
+++ b/apps/cli/lib/src/codegen/cloud_code_generator.dart
@@ -43,7 +43,7 @@ final class CloudCodeGenerator extends AstVisitor<void> {
         library.value,
         forFile: filePath,
         pathStrategy: PathStrategy.pretty,
-        prefixingStrategy: PrefixingStrategy.none,
+        prefixingStrategy: PrefixingStrategy.pretty,
       );
     }
 


### PR DESCRIPTION
To avoid name clashing between `context` from `package:celest` and the top-level generated `context` variable.