### PR TITLE
chore(auth): Make `close` part of the public API

### DIFF
--- a/packages/celest_auth/lib/src/auth.dart
+++ b/packages/celest_auth/lib/src/auth.dart
@@ -28,4 +28,7 @@ abstract interface class Auth {
 
   /// Signs out the current user, if any.
   Future<void> signOut();
+
+  /// Closes the Auth plugin.
+  Future<void> close();
 }

--- a/packages/celest_auth/lib/src/auth_impl.dart
+++ b/packages/celest_auth/lib/src/auth_impl.dart
@@ -219,6 +219,7 @@ final class AuthImpl implements Auth {
   NativeStorage get localStorage => _storage;
   IsolatedNativeStorage get secureStorage => _storage.secure.isolated;
 
+  @override
   Future<void> close() async {
     for (final subscription in _authProviderSubs.values) {
       subscription.cancel().ignore();
@@ -227,7 +228,5 @@ final class AuthImpl implements Auth {
     await _authStateSubscription?.cancel();
     await _authFlowSubscription?.cancel();
     await _authStateController.close();
-    localStorage.close();
-    await secureStorage.close();
   }
 }


### PR DESCRIPTION
So that it can be called in generated client code.