### PR TITLE
chore(cli): Add full reset to generated client

### DIFF
--- a/apps/cli/fixtures/standalone/api/client/lib/api_client.dart
+++ b/apps/cli/fixtures/standalone/api/client/lib/api_client.dart
@@ -152,11 +152,16 @@ class Celest with _$celest.CelestBase {
     CelestEnvironment environment = CelestEnvironment.local,
     _$celest.Serializers? serializers,
   }) {
+    if (_initialized) {
+      _reset();
+    }
     _currentEnvironment = environment;
     _baseUri = environment.baseUri;
-    if (!_initialized) {
-      initSerializers(serializers: serializers);
-    }
+    initSerializers(serializers: serializers);
     _initialized = true;
+  }
+
+  void _reset() {
+    _initialized = false;
   }
 }

--- a/apps/cli/fixtures/standalone/auth/client/lib/auth_client.dart
+++ b/apps/cli/fixtures/standalone/auth/client/lib/auth_client.dart
@@ -50,7 +50,7 @@ class Celest with _$celest.CelestBase {
 
   final _functions = CelestFunctions();
 
-  late final CelestAuth _auth = CelestAuth(
+  late CelestAuth _auth = CelestAuth(
     this,
     storage: nativeStorage,
   );
@@ -77,15 +77,22 @@ class Celest with _$celest.CelestBase {
     CelestEnvironment environment = CelestEnvironment.local,
     _$celest.Serializers? serializers,
   }) {
-    if (_initialized && environment != _currentEnvironment) {
-      _auth.signOut();
+    if (_initialized) {
+      _reset();
     }
     _currentEnvironment = environment;
     _baseUri = environment.baseUri;
     scheduleMicrotask(() => _auth.init());
-    if (!_initialized) {
-      initSerializers(serializers: serializers);
-    }
+    initSerializers(serializers: serializers);
     _initialized = true;
+  }
+
+  void _reset() {
+    _auth.close().ignore();
+    _auth = CelestAuth(
+      this,
+      storage: nativeStorage,
+    );
+    _initialized = false;
   }
 }

--- a/apps/cli/fixtures/standalone/data/client/lib/data_client.dart
+++ b/apps/cli/fixtures/standalone/data/client/lib/data_client.dart
@@ -68,11 +68,16 @@ class Celest with _$celest.CelestBase {
     CelestEnvironment environment = CelestEnvironment.local,
     _$celest.Serializers? serializers,
   }) {
+    if (_initialized) {
+      _reset();
+    }
     _currentEnvironment = environment;
     _baseUri = environment.baseUri;
-    if (!_initialized) {
-      initSerializers(serializers: serializers);
-    }
+    initSerializers(serializers: serializers);
     _initialized = true;
+  }
+
+  void _reset() {
+    _initialized = false;
   }
 }

--- a/apps/cli/fixtures/standalone/env_vars/client/lib/env_vars_client.dart
+++ b/apps/cli/fixtures/standalone/env_vars/client/lib/env_vars_client.dart
@@ -67,11 +67,16 @@ class Celest with _$celest.CelestBase {
     CelestEnvironment environment = CelestEnvironment.local,
     _$celest.Serializers? serializers,
   }) {
+    if (_initialized) {
+      _reset();
+    }
     _currentEnvironment = environment;
     _baseUri = environment.baseUri;
-    if (!_initialized) {
-      initSerializers(serializers: serializers);
-    }
+    initSerializers(serializers: serializers);
     _initialized = true;
+  }
+
+  void _reset() {
+    _initialized = false;
   }
 }

--- a/apps/cli/fixtures/standalone/exceptions/client/lib/exceptions_client.dart
+++ b/apps/cli/fixtures/standalone/exceptions/client/lib/exceptions_client.dart
@@ -68,11 +68,16 @@ class Celest with _$celest.CelestBase {
     CelestEnvironment environment = CelestEnvironment.local,
     _$celest.Serializers? serializers,
   }) {
+    if (_initialized) {
+      _reset();
+    }
     _currentEnvironment = environment;
     _baseUri = environment.baseUri;
-    if (!_initialized) {
-      initSerializers(serializers: serializers);
-    }
+    initSerializers(serializers: serializers);
     _initialized = true;
+  }
+
+  void _reset() {
+    _initialized = false;
   }
 }

--- a/apps/cli/fixtures/standalone/flutter/client/lib/flutter_client.dart
+++ b/apps/cli/fixtures/standalone/flutter/client/lib/flutter_client.dart
@@ -67,11 +67,16 @@ class Celest with _$celest.CelestBase {
     CelestEnvironment environment = CelestEnvironment.local,
     _$celest.Serializers? serializers,
   }) {
+    if (_initialized) {
+      _reset();
+    }
     _currentEnvironment = environment;
     _baseUri = environment.baseUri;
-    if (!_initialized) {
-      initSerializers(serializers: serializers);
-    }
+    initSerializers(serializers: serializers);
     _initialized = true;
+  }
+
+  void _reset() {
+    _initialized = false;
   }
 }

--- a/apps/cli/fixtures/standalone/http/client/lib/api_client.dart
+++ b/apps/cli/fixtures/standalone/http/client/lib/api_client.dart
@@ -76,11 +76,16 @@ class Celest with _$celest.CelestBase {
     CelestEnvironment environment = CelestEnvironment.local,
     _$celest.Serializers? serializers,
   }) {
+    if (_initialized) {
+      _reset();
+    }
     _currentEnvironment = environment;
     _baseUri = environment.baseUri;
-    if (!_initialized) {
-      initSerializers(serializers: serializers);
-    }
+    initSerializers(serializers: serializers);
     _initialized = true;
+  }
+
+  void _reset() {
+    _initialized = false;
   }
 }

--- a/apps/cli/fixtures/standalone/marcelo/client/lib/marcelo_client.dart
+++ b/apps/cli/fixtures/standalone/marcelo/client/lib/marcelo_client.dart
@@ -72,11 +72,16 @@ class Celest with _$celest.CelestBase {
     CelestEnvironment environment = CelestEnvironment.local,
     _$celest.Serializers? serializers,
   }) {
+    if (_initialized) {
+      _reset();
+    }
     _currentEnvironment = environment;
     _baseUri = environment.baseUri;
-    if (!_initialized) {
-      initSerializers(serializers: serializers);
-    }
+    initSerializers(serializers: serializers);
     _initialized = true;
+  }
+
+  void _reset() {
+    _initialized = false;
   }
 }

--- a/apps/cli/fixtures/standalone/simple/client/lib/simple_client.dart
+++ b/apps/cli/fixtures/standalone/simple/client/lib/simple_client.dart
@@ -43,7 +43,14 @@ class Celest {
     CelestEnvironment environment = CelestEnvironment.local,
     _$celest.Serializers? serializers,
   }) {
+    if (_initialized) {
+      _reset();
+    }
     _currentEnvironment = environment;
     _initialized = true;
+  }
+
+  void _reset() {
+    _initialized = false;
   }
 }

--- a/apps/cli/fixtures/standalone/streaming/client/lib/streaming_client.dart
+++ b/apps/cli/fixtures/standalone/streaming/client/lib/streaming_client.dart
@@ -65,11 +65,16 @@ class Celest with _$celest.CelestBase {
     CelestEnvironment environment = CelestEnvironment.local,
     _$celest.Serializers? serializers,
   }) {
+    if (_initialized) {
+      _reset();
+    }
     _currentEnvironment = environment;
     _baseUri = environment.baseUri;
-    if (!_initialized) {
-      initSerializers(serializers: serializers);
-    }
+    initSerializers(serializers: serializers);
     _initialized = true;
+  }
+
+  void _reset() {
+    _initialized = false;
   }
 }

--- a/apps/cli/lib/src/codegen/allocator.dart
+++ b/apps/cli/lib/src/codegen/allocator.dart
@@ -44,7 +44,7 @@ final class CelestAllocator implements Allocator {
             clientPackageName ?? celestProject.clientPackageName,
         projectPaths = projectPaths ?? celestProject.projectPaths;
 
-  static const _doNotPrefix = ['dart:core', 'package:meta/meta.dart'];
+  static const _doNotPrefix = ['dart:core'];
   static final Logger _logger = Logger('CelestAllocator');
 
   final String forFile;

--- a/apps/cli/lib/src/types/dart_types.dart
+++ b/apps/cli/lib/src/types/dart_types.dart
@@ -951,6 +951,10 @@ class _Meta {
 
   /// Creates a [meta.immutable] reference.
   DartTypeReference get immutable => const DartTypeReference('immutable', _url);
+
+  /// Creates a [meta.visibleForTesting] reference.
+  DartTypeReference get visibleForTesting =>
+      const DartTypeReference('visibleForTesting', _url);
 }
 
 /// `package:native_storage` types


### PR DESCRIPTION
This is mostly useful in testing when multiple `celest.init` calls are made by closing out the Auth client and creating a new one.