### PR TITLE
chore(cli): Pass Celest's VM service URI to auxiliary start commands

### DIFF
--- a/apps/cli/lib/src/compiler/api/local_api_runner.dart
+++ b/apps/cli/lib/src/compiler/api/local_api_runner.dart
@@ -41,6 +41,9 @@ final class LocalApiRunner {
   VmService? _vmService;
   late final String _vmIsolateId;
 
+  /// The WebSocket URI of the running Celest server.
+  String get wsUri => _vmService!.wsUri!;
+
   late final StreamSubscription<String> _stdoutSub;
   late final StreamSubscription<String> _stderrSub;
 

--- a/apps/cli/lib/src/frontend/celest_frontend.dart
+++ b/apps/cli/lib/src/frontend/celest_frontend.dart
@@ -349,6 +349,11 @@ final class CelestFrontend {
                 'Celest is running and watching for updates',
               );
               cliLogger.detail('Local API running at: $localUri');
+              if (verbose) {
+                cliLogger.detail(
+                  'VM Service URI: ${_localApiRunner!.wsUri}',
+                );
+              }
             } else {
               currentProgress!.complete('Reloaded project');
             }
@@ -358,7 +363,11 @@ final class CelestFrontend {
             if (childProcess case final childProcess?
                 when !childProcess.isStarted) {
               logger.info('Running command: ${childProcess.command.join(' ')}');
-              await childProcess.start();
+              await childProcess.start(
+                dartDefines: {
+                  'CELEST_SERVICE_WS_URI': _localApiRunner!.wsUri,
+                },
+              );
               unawaited(
                 _stopSignal.future.then(childProcess.stop),
               );

--- a/apps/cli/lib/src/frontend/child_process.dart
+++ b/apps/cli/lib/src/frontend/child_process.dart
@@ -26,12 +26,39 @@ final class ChildProcess {
   }
 
   /// Starts the process and streams stdout/stderr to the console.
+  ///
+  /// If [environment] is not null, it is passed to [Process.start].
+  ///
+  /// If [dartDefines] are specified and the [command] is a `dart` or `flutter`
+  /// command, then the given values are passed to the command via the respective
+  /// flag.
   Future<void> start({
     Map<String, String>? environment,
+    Map<String, String>? dartDefines,
   }) async {
     if (_process != null) {
       return;
     }
+
+    var command = this.command;
+    if (dartDefines != null) {
+      switch (command.first) {
+        case 'dart':
+          command = [
+            'dart',
+            for (final MapEntry(:key, :value) in dartDefines.entries)
+              '-D$key=$value',
+            ...command.sublist(1),
+          ];
+        case 'flutter':
+          command = [
+            ...command,
+            for (final MapEntry(:key, :value) in dartDefines.entries)
+              '--dart-define=$key=$value'
+          ];
+      }
+    }
+
     final process = _process = await processManager.start(
       command,
       environment: environment,


### PR DESCRIPTION
When running `celest start` with an auxiliary command, pass the running server's VM service URI to the command as a Dart define.

This is useful when the auxiliary command is `dart test` or `flutter test` and allows `package:celest_test` to get live updates from the server in an integration test.