### PR TITLE
feat: Add `celest_test` package

### DIFF
--- a/packages/celest_test/.gitignore
+++ b/packages/celest_test/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/celest_test/CHANGELOG.md
+++ b/packages/celest_test/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Initial version.

--- a/packages/celest_test/README.md
+++ b/packages/celest_test/README.md
@@ -1,0 +1,3 @@
+# Celest Test
+
+Helper package for running integration tests with Celest.

--- a/packages/celest_test/analysis_options.yaml
+++ b/packages/celest_test/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:celest_lints/library.yaml

--- a/packages/celest_test/lib/celest_test.dart
+++ b/packages/celest_test/lib/celest_test.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service_io.dart';
+
+/// A helper class for running integration tests with Celest.
+final class CelestTester {
+  CelestTester._(this._vmService);
+
+  /// Connects to the Celest service running at the given [wsUri].
+  ///
+  /// Typically, this value is populated automatically by running
+  /// `celest start` followed by a command like `flutter test`.
+  static Future<CelestTester> connect({
+    String wsUri = const String.fromEnvironment('CELEST_SERVICE_WS_URI'),
+  }) async {
+    _logger.fine('Connecting to Celest service: $wsUri');
+
+    var uri = Uri.parse(wsUri);
+    if (uri.host case '127.0.0.1' || 'localhost' when Platform.isAndroid) {
+      uri = uri.replace(host: '10.0.2.2');
+    }
+
+    final vmService = await vmServiceConnectUri(uri.toString());
+    await vmService.streamListen(EventStreams.kExtension);
+
+    final tester = CelestTester._(vmService);
+    addTearDown(tester.close);
+    return tester;
+  }
+
+  static final Logger _logger = Logger('CelestTester');
+
+  final VmService _vmService;
+
+  /// Closes the connection to the VM service.
+  Future<void> close() async {
+    await _vmService.dispose();
+  }
+}

--- a/packages/celest_test/pubspec.yaml
+++ b/packages/celest_test/pubspec.yaml
@@ -1,0 +1,18 @@
+name: celest_test
+description: Helper package for running integration tests with Celest.
+version: 0.1.0
+homepage: https://celest.dev
+repository: https://github.com/celest-dev/celest/tree/main/packages/celest_test
+
+environment:
+  sdk: ^3.5.0
+resolution: workspace
+
+dependencies:
+  async: ^2.11.0
+  logging: ^1.3.0
+  test: ^1.25.15
+  vm_service: '>=14.0.0 <16.0.0'
+
+dev_dependencies:
+  celest_lints: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ workspace:
   - packages/celest_cloud
   - packages/celest_core
   - packages/celest_lints
+  - packages/celest_test
   - services/celest_cloud_auth
 
 dev_dependencies:


### PR DESCRIPTION
Adds the initial version of the `celest_test` package for running integration tests with Celest.