### PR TITLE
chore(auth): Add `celest_test` helper for email OTP events

### DIFF
--- a/services/celest_cloud_auth/lib/src/email/email_provider.dart
+++ b/services/celest_cloud_auth/lib/src/email/email_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:celest_cloud_auth/src/context.dart';
 import 'package:celest_cloud_auth/src/otp/otp_provider.dart';
 
@@ -7,6 +9,7 @@ extension type const EmailOtpProvider._(OtpSender _send) implements Object {
   const EmailOtpProvider([OtpSender send = _defaultSend]) : this._(send);
 
   static Future<void> _defaultSend(Otp message) async {
+    developer.postEvent('celest.cloud_auth.emailOtpSent', message.toJson());
     context.logger.info('Verification code for ${message.to}: ${message.code}');
   }
 

--- a/services/celest_cloud_auth/lib/src/otp/otp_provider.dart
+++ b/services/celest_cloud_auth/lib/src/otp/otp_provider.dart
@@ -3,4 +3,8 @@ typedef Otp = ({
   String code,
 });
 
+extension OtpX on Otp {
+  Map<String, Object?> toJson() => {'to': to, 'code': code};
+}
+
 typedef OtpSender = Future<void> Function(Otp);


### PR DESCRIPTION
Adds the ability to monitor email OTP events in `package:celest_test` so that full E2E tests can be performed.