### PR TITLE
ci: Fix celest_auth tests

### DIFF
--- a/.github/workflows/celest_auth.yaml
+++ b/.github/workflows/celest_auth.yaml
@@ -19,7 +19,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: macos-latest-xlarge
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Git Checkout
@@ -63,6 +63,7 @@ jobs:
         working-directory: packages/celest_auth/example
         run: flutter pub get
       - name: Setup iOS Simulator
+        id: simulator
         run: |
           RUNTIME=$(xcrun simctl list runtimes | grep 'iOS 18' | tail -n 1 | cut -d' ' -f 7)
           echo "Using runtime: $RUNTIME"
@@ -70,12 +71,32 @@ jobs:
           echo "Booting simulator"
           xcrun simctl boot ios
           echo "Booted simulator"
+          xcrun simctl io booted recordVideo --codec=h264 /tmp/test.mp4 &
+          echo "recording_pid=$!" >> $GITHUB_OUTPUT
       - name: Integration Test (iOS)
+        id: test-ios
+        continue-on-error: true
         working-directory: packages/celest_auth/example
         run: dart run $CELEST start --verbose -- flutter test -d ios integration_test
-      - name: Integration Test (macOS)
-        working-directory: packages/celest_auth/example
-        run: dart run $CELEST start --verbose -- flutter test -d macos integration_test
+      - name: Stop recording
+        if: always()
+        run: |
+          kill -INT ${{ steps.simulator.outputs.recording_pid }}
+          sleep 5 # Give some time for the video to save
+      - name: Upload test video recording
+        if: steps.test-ios.outcome == 'failure'  # Only upload if tests failed
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        with:
+          name: test-recording
+          path: /tmp/test.mp4
+          retention-days: 7
+      - name: Fail job if tests failed
+        if: steps.test-ios.outcome == 'failure'
+        run: exit 1
+      # TODO: Need signing certs in CI to test
+      # - name: Integration Test (macOS)
+      #   working-directory: packages/celest_auth/example
+      #   run: dart run $CELEST start --verbose -- flutter test -d macos integration_test
   # TODO: Keeps timing out on Linux. Fails hard on macOS...
   # test_android:
   #   needs: [test]

--- a/packages/celest_auth/example/integration_test/integration_test.dart
+++ b/packages/celest_auth/example/integration_test/integration_test.dart
@@ -14,7 +14,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Initial state is signed out.
-    expect(find.byKey(TestKeys.txtSignedOut), findsOneWidget);
+    expect(find.byKey(TestKeys.txtSignedOut), findsOne);
 
     // Send an unauthenticated request.
     await tester.tap(find.byKey(TestKeys.btnMakeRequest));
@@ -24,7 +24,7 @@ void main() {
         of: find.byKey(TestKeys.wMakeRequestResponse),
         matching: find.textContaining('Error'),
       ),
-      findsOneWidget,
+      findsOne,
     );
   });
 
@@ -36,7 +36,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Initial state is signed out.
-    expect(find.byKey(TestKeys.txtSignedOut), findsOneWidget);
+    expect(find.byKey(TestKeys.txtSignedOut), findsOne);
 
     // Sign in with email.
     await tester.enterText(
@@ -51,10 +51,15 @@ void main() {
     );
 
     await tester.tap(find.byKey(TestKeys.btnSignIn));
+
+    await expectLater(
+      celest.auth.authStateChanges,
+      emitsThrough(isA<AuthFlowInProgress>()),
+    );
     await tester.pumpAndSettle();
 
-    expect(find.byKey(TestKeys.inOtp), findsOneWidget);
-    expect(find.byKey(TestKeys.btnVerifyOtp), findsOneWidget);
+    expect(find.byKey(TestKeys.inOtp), findsOne);
+    expect(find.byKey(TestKeys.btnVerifyOtp), findsOne);
   });
 
   testWidgets('signs in/out', (tester) async {
@@ -65,7 +70,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Initial state is signed out.
-    expect(find.byKey(TestKeys.txtSignedOut), findsOneWidget);
+    expect(find.byKey(TestKeys.txtSignedOut), findsOne);
 
     // Sign in with email.
     await tester.enterText(
@@ -74,14 +79,24 @@ void main() {
     );
     final otpCode = celestTester.auth.onSentOtp.first;
     await tester.tap(find.byKey(TestKeys.btnSignIn));
+
+    await expectLater(
+      celest.auth.authStateChanges,
+      emitsThrough(isA<AuthFlowInProgress>()),
+    );
     await tester.pumpAndSettle();
 
     // Enter OTP code received.
     await tester.enterText(find.byKey(TestKeys.inOtp), (await otpCode).code);
     await tester.tap(find.byKey(TestKeys.btnVerifyOtp));
+
+    await expectLater(
+      celest.auth.authStateChanges,
+      emitsThrough(isA<Authenticated>()),
+    );
     await tester.pumpAndSettle();
 
-    expect(find.byKey(TestKeys.txtSignedIn), findsOneWidget);
+    expect(find.byKey(TestKeys.txtSignedIn), findsOne);
 
     // Make authenticated request
     await tester.tap(find.byKey(TestKeys.btnMakeRequest));
@@ -92,13 +107,18 @@ void main() {
         of: find.byKey(TestKeys.wMakeRequestResponse),
         matching: find.textContaining('Response'),
       ),
-      findsOneWidget,
+      findsOne,
     );
 
     // Sign out
     await tester.tap(find.byKey(TestKeys.btnSignOut));
+
+    await expectLater(
+      celest.auth.authStateChanges,
+      emitsThrough(isA<Unauthenticated>()),
+    );
     await tester.pumpAndSettle();
 
-    expect(find.byKey(TestKeys.txtSignedOut), findsOneWidget);
+    expect(find.byKey(TestKeys.txtSignedOut), findsOne);
   });
 }


### PR DESCRIPTION
- Remove macOS integration tests for now, since they'll require a dev cert in CI to run.
- Correct tests for slow I/O
- Add fallback to upload recorded video on failure