### PR TITLE
fix(runtime): Treat database host values as DSN strings

### DIFF
--- a/packages/celest/test/runtime/data/connect_test.dart
+++ b/packages/celest/test/runtime/data/connect_test.dart
@@ -102,7 +102,7 @@ void main() {
         }
       });
 
-      final platform = FakePlatform();
+      final platform = FakePlatform(environment: {});
       Context.current.put(env.environment, 'local');
       Context.current.put(ContextKey.platform, platform);
       final database = await connect(
@@ -124,7 +124,7 @@ void main() {
       final tmpDir = await Directory.systemTemp.createTemp('celest_test');
       addTearDown(() => tmpDir.delete(recursive: true));
 
-      final platform = FakePlatform();
+      final platform = FakePlatform(environment: {});
       Context.current.put(env.environment, 'local');
       Context.current.put(ContextKey.platform, platform);
       final database = await connect(


### PR DESCRIPTION
Allow setting host values for in-memory, file, and remote sources.