### PR TITLE
fix(cli): Rename database environment variables

### DIFF
--- a/apps/cli/fixtures/standalone/data/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/data/goldens/celest.json
@@ -43,11 +43,11 @@
       },
       "celest": {
         "hostname": {
-          "name": "CELEST_DATABASE_HOST",
+          "name": "TASK_DATABASE_HOST",
           "value": ""
         },
         "token": {
-          "name": "CELEST_DATABASE_TOKEN",
+          "name": "TASK_DATABASE_TOKEN",
           "value": ""
         }
       }

--- a/apps/cli/fixtures/standalone/data/lib/src/generated/data.celest.dart
+++ b/apps/cli/fixtures/standalone/data/lib/src/generated/data.celest.dart
@@ -24,8 +24,8 @@ class CelestData {
         context,
         name: 'TaskDatabase',
         factory: TaskDatabase.new,
-        hostnameVariable: const _$celest.env('CELEST_DATABASE_HOST'),
-        tokenSecret: const _$celest.secret('CELEST_DATABASE_TOKEN'),
+        hostnameVariable: const _$celest.env('TASK_DATABASE_HOST'),
+        tokenSecret: const _$celest.secret('TASK_DATABASE_TOKEN'),
       ),
     );
   }

--- a/apps/cli/lib/src/analyzer/celest_analyzer.dart
+++ b/apps/cli/lib/src/analyzer/celest_analyzer.dart
@@ -348,10 +348,8 @@ const project = Project(name: 'cache_warmup');
       'resolveDatabases',
       _resolveDatabases,
     );
-    if (databases.isNotEmpty) {
-      _project.databases.addAll({
-        for (final database in databases) database.name: database,
-      });
+    for (final database in databases) {
+      _project.databases[database.name] = database;
     }
 
     if (migrateProject) {

--- a/apps/cli/lib/src/analyzer/resolver/project_resolver.dart
+++ b/apps/cli/lib/src/analyzer/resolver/project_resolver.dart
@@ -21,6 +21,7 @@ import 'package:celest_cli/src/types/type_checker.dart';
 import 'package:celest_cli/src/utils/analyzer.dart';
 import 'package:celest_cli/src/utils/error.dart';
 import 'package:celest_cli/src/utils/list.dart';
+import 'package:celest_cli/src/utils/recase.dart';
 import 'package:celest_cli/src/utils/reference.dart';
 import 'package:celest_cli/src/utils/run.dart';
 import 'package:celest_cli/src/version.dart';
@@ -1264,8 +1265,9 @@ final class CelestProjectResolver with CelestAnalysisHelpers {
     }
 
     final schemaTypeReference = typeHelper.toReference(driftDatabaseType);
+    final databaseName = schemaTypeReference.symbol!;
     return ast.Database(
-      name: schemaTypeReference.symbol!,
+      name: databaseName,
       dartName: databaseDefinitionElement.name,
       docs: databaseDefinitionElement.docLines,
       schema: ast.DriftDatabaseSchema(
@@ -1274,11 +1276,11 @@ final class CelestProjectResolver with CelestAnalysisHelpers {
       ),
       config: ast.CelestDatabaseConfig(
         hostname: ast.Variable(
-          'CELEST_DATABASE_HOST',
+          '${databaseName.screamingCase}_HOST',
           location: databaseDefinitionLocation,
         ),
         token: ast.Secret(
-          'CELEST_DATABASE_TOKEN',
+          '${databaseName.screamingCase}_TOKEN',
           location: databaseDefinitionLocation,
         ),
       ),

--- a/apps/cli/lib/src/utils/recase.dart
+++ b/apps/cli/lib/src/utils/recase.dart
@@ -24,6 +24,9 @@ extension StringRecase on String {
   /// The `snake_case` version of `this`.
   String get snakeCase => groupIntoWords().snakeCase;
 
+  /// The `SCREAMING_CASE` version of `this`.
+  String get screamingCase => groupIntoWords().screamingCase;
+
   // "acm-success"-> "acm success"
   static final _nonAlphaNumericChars = RegExp(r'[^A-Za-z0-9+]');
 
@@ -123,4 +126,7 @@ extension type WordGroup(List<String> _group) implements List<String> {
 
   /// The `snake_case` version of `this`.
   String get snakeCase => map((word) => word.toLowerCase()).join('_');
+
+  /// The `SCREAMING_CASE` version of `this`.
+  String get screamingCase => map((word) => word.toUpperCase()).join('_');
 }


### PR DESCRIPTION
Use `${DATABASE_NAME}_HOST` and `${DATABASE_NAME}_TOKEN` instead of a hardcoded value.