### PR TITLE
chore(celest): Remove `@internal` from `set Context.root`

### DIFF
--- a/packages/celest/CHANGELOG.md
+++ b/packages/celest/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+- chore: Remove `@internal` from `set Context.root`
+
 ## 1.0.3
 
 - fix(runtime): Treat database host values as DSN strings (#276)

--- a/packages/celest/lib/src/core/context.dart
+++ b/packages/celest/lib/src/core/context.dart
@@ -49,9 +49,6 @@ final class Context {
   }
 
   /// Sets the root [Context] for the current execution scope.
-  ///
-  /// This is only allowed in tests.
-  @internal
   static set root(Context value) {
     if (_root != null && kReleaseMode) {
       throw UnsupportedError(


### PR DESCRIPTION
This is used in multiple places now, it has use cases outside `package:celest` anywhere you want to control what the root context zone is, e.g. tests.