### PR TITLE
chore(cloud): Improve gRPC interface

### DIFF
--- a/packages/celest_cloud/CHANGELOG.md
+++ b/packages/celest_cloud/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - feat: Add `Operations.waitOperation`
 - chore: Update license
+- chore: Improve gRPC interface
 
 # 0.1.4
 


### PR DESCRIPTION
- Add separate `.http` and `.grpc` dedicated constructors
- Allow specifying an `InternetAddress` for the gRPC host, e.g. a UNIX socket