### PR TITLE
ci: Use smaller macOS runners

### DIFF
--- a/.github/workflows/celest.yaml
+++ b/.github/workflows/celest.yaml
@@ -54,7 +54,7 @@ jobs:
         run: dart test -p chrome -c dart2wasm
   test_darwin:
     needs: [test]
-    runs-on: macos-latest-xlarge
+    runs-on: macos-latest
     timeout-minutes: 20
     steps:
       - name: Git Checkout
@@ -86,7 +86,7 @@ jobs:
   # TODO: Keeps timing out on Linux. Fails hard on macOS...
   # test_android:
   #   needs: [test]
-  #   runs-on: macos-latest-xlarge
+  #   runs-on: macos-latest
   #   timeout-minutes: 30
   #   steps:
   #     - name: Git Checkout

--- a/.github/workflows/celest_auth.yaml
+++ b/.github/workflows/celest_auth.yaml
@@ -47,7 +47,7 @@ jobs:
       #   run: dart test
   test_darwin:
     needs: [test]
-    runs-on: macos-latest-xlarge
+    runs-on: macos-latest
     timeout-minutes: 20
     steps:
       - name: Git Checkout
@@ -100,7 +100,7 @@ jobs:
   # TODO: Keeps timing out on Linux. Fails hard on macOS...
   # test_android:
   #   needs: [test]
-  #   runs-on: macos-latest-xlarge
+  #   runs-on: macos-latest
   #   timeout-minutes: 30
   #   steps:
   #     - name: Git Checkout


### PR DESCRIPTION
To avoid the costs of XL runners which are not currently worth it.