### PR TITLE
feat(cli): Add basic OpenAPI loading/rendering

### DIFF
--- a/apps/cli/lib/src/openapi/ast/openapi_ast.dart
+++ b/apps/cli/lib/src/openapi/ast/openapi_ast.dart
@@ -1,0 +1,2054 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/json_object.dart';
+import 'package:celest_cli/src/openapi/ast/openapi_visitor.dart';
+import 'package:celest_cli/src/openapi/type/json_type.dart';
+import 'package:celest_cli/src/openapi/type/json_type_format.spec.dart';
+import 'package:collection/collection.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart';
+
+part 'openapi_ast.g.dart';
+part 'openapi_reference.dart';
+
+abstract interface class OpenApiNode {
+  String? get ref;
+  YamlNode? get node;
+
+  R accept<R>(OpenApiVisitor<R> visitor);
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg);
+}
+
+@BuiltValue(instantiable: false)
+sealed class OpenApiComponent<T extends OpenApiComponent<T>>
+    implements OpenApiNode {
+  String? get summary;
+  String? get description;
+
+  OpenApiComponentBuilder<T> toBuilder();
+  T rebuild(void Function(OpenApiComponentBuilder<T> b) updates);
+}
+
+/// This is the root object of the OpenAPI document.
+///
+/// https://spec.openapis.org/oas/v3.1.0#openapi-object
+abstract class OpenApiDocument
+    implements Built<OpenApiDocument, OpenApiDocumentBuilder>, OpenApiNode {
+  factory OpenApiDocument({
+    required Version version,
+    required OpenApiInfo info,
+    String? jsonSchemaDialect,
+    List<OpenApiServer>? servers,
+    Map<String, OpenApiComponentOrRef<OpenApiPathItem>>? paths,
+    OpenApiComponents? components,
+    List<OpenApiSecurityRequirement>? securityRequirements,
+  }) {
+    return _$OpenApiDocument._(
+      version: version,
+      info: info,
+      jsonSchemaDialect: jsonSchemaDialect,
+      servers: (servers ?? [OpenApiServer(url: '/')]).build(),
+      paths: (paths ?? {}).build(),
+      components: components ?? OpenApiComponents(),
+      securityRequirements: (securityRequirements ?? []).build(),
+    );
+  }
+
+  factory OpenApiDocument.build(
+    void Function(OpenApiDocumentBuilder) updates,
+  ) = _$OpenApiDocument;
+
+  OpenApiDocument._();
+
+  /// REQUIRED. This string MUST be the version number of the OpenAPI
+  /// Specification that the OpenAPI document uses.
+  ///
+  /// The openapi field SHOULD be used by tooling to interpret the OpenAPI
+  /// document.
+  ///
+  /// This is not related to the API [OpenApiInfo.apiVersion]
+  /// (`info.version`) string.
+  @JsonKey(name: 'openapi')
+  Version get version;
+
+  /// REQUIRED. Provides metadata about the API.
+  ///
+  /// The metadata MAY be used by tooling as required.
+  OpenApiInfo get info;
+
+  /// The default value for the $schema keyword within Schema Objects contained
+  /// within this OAS document.
+  ///
+  /// This MUST be in the form of a URI.
+  String? get jsonSchemaDialect;
+
+  /// An array of Server Objects, which provide connectivity information to a
+  /// target server.
+  ///
+  /// If the servers property is not provided, or is an empty array, the
+  /// default value would be a Server Object with a url value of /.
+  BuiltList<OpenApiServer> get servers;
+
+  /// The available paths and operations for the API.
+  ///
+  /// The key of this map is a relative path to an individual endpoint.
+  ///
+  /// The field name MUST begin with a forward slash (/). The path is appended
+  /// (no relative URL resolution) to the expanded URL from the Server Object's
+  /// [OpenApiServer.url] field in order to construct the full URL.
+  ///
+  /// Path templating is allowed. When matching URLs, concrete (non-templated)
+  /// paths would be matched before their templated counterparts. Templated
+  /// paths with the same hierarchy but different templated names MUST NOT
+  /// exist as they are identical. In case of ambiguous matching, it's up to
+  /// the tooling to decide which one to use.
+  BuiltMap<String, OpenApiComponentOrRef<OpenApiPathItem>> get paths;
+
+  // TODO(dnys1): webhooks
+
+  /// An element to hold various schemas for the specification.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#components-object
+  OpenApiComponents get components;
+
+  /// A declaration of which security mechanisms can be used across the API.
+  /// The list of values includes alternative security requirement objects that
+  /// can be used. Only one of the security requirement objects need to be valid
+  /// at any point in time.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#security-requirement-object
+  BuiltList<OpenApiSecurityRequirement> get securityRequirements;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitDocument(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitDocument(this, arg);
+}
+
+abstract class OpenApiInfo
+    implements Built<OpenApiInfo, OpenApiInfoBuilder>, OpenApiNode {
+  factory OpenApiInfo({
+    String? title,
+    String? description,
+    String? apiVersion,
+  }) {
+    return _$OpenApiInfo._(
+      title: title,
+      description: description,
+      apiVersion: apiVersion,
+    );
+  }
+
+  factory OpenApiInfo.build(
+    void Function(OpenApiInfoBuilder) updates,
+  ) = _$OpenApiInfo;
+
+  OpenApiInfo._();
+
+  String? get title;
+  String? get description;
+  String? get apiVersion;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitInfo(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitInfo(this, arg);
+}
+
+/// An object representing a Server.
+///
+/// https://spec.openapis.org/oas/v3.1.0#server-object
+abstract class OpenApiServer
+    implements Built<OpenApiServer, OpenApiServerBuilder>, OpenApiNode {
+  factory OpenApiServer({
+    required String url,
+    String? description,
+    Map<String, OpenApiServerVariable>? variables,
+  }) {
+    return _$OpenApiServer._(
+      url: url,
+      description: description,
+      variables: (variables ?? {}).build(),
+    );
+  }
+
+  factory OpenApiServer.build(
+    void Function(OpenApiServerBuilder) updates,
+  ) = _$OpenApiServer;
+
+  OpenApiServer._();
+
+  /// REQUIRED. A URL to the target host.
+  ///
+  /// This URL supports Server Variables and MAY be relative, to indicate that
+  /// the host location is relative to the location where the OpenAPI document
+  /// is being served. Variable substitutions will be made when a variable is
+  /// named in {brackets}.
+  String get url;
+
+  // TODO(dnys1): Provide citation
+  /// May be relative or absolute.
+  Uri get uri => Uri.parse(url);
+
+  /// An optional string describing the host designated by the URL.
+  ///
+  /// CommonMark syntax MAY be used for rich text representation.
+  String? get description;
+
+  /// A map between a variable name and its value.
+  ///
+  /// The value is used for substitution in the server's URL template.
+  BuiltMap<String, OpenApiServerVariable> get variables;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitServer(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitServer(this, arg);
+}
+
+/// An object representing a Server Variable for server URL template
+/// substitution.
+///
+/// https://spec.openapis.org/oas/v3.1.0#server-variable-object
+abstract class OpenApiServerVariable
+    implements
+        Built<OpenApiServerVariable, OpenApiServerVariableBuilder>,
+        OpenApiNode {
+  factory OpenApiServerVariable({
+    required String name,
+    required String defaultValue,
+    String? description,
+    Iterable<String>? enumValues,
+  }) {
+    return _$OpenApiServerVariable._(
+      name: name,
+      defaultValue: defaultValue,
+      description: description,
+      enumValues: enumValues?.toBuiltList(),
+    );
+  }
+
+  factory OpenApiServerVariable.build(
+    void Function(OpenApiServerVariableBuilder) updates,
+  ) = _$OpenApiServerVariable;
+
+  OpenApiServerVariable._();
+
+  String get name;
+
+  /// An enumeration of string values to be used if the substitution options
+  /// are from a limited set.
+  ///
+  /// The array MUST NOT be empty if provided.
+  @JsonKey(name: 'enum')
+  BuiltList<String>? get enumValues;
+
+  /// REQUIRED. The default value to use for substitution, which SHALL be sent
+  /// if an alternate value is not supplied.
+  ///
+  /// Note this behavior is different than the Schema Object's treatment of
+  /// default values, because in those cases parameter values are optional.
+  /// If the enum is defined, the value MUST exist in the enum's values.
+  @JsonKey(name: 'default')
+  String get defaultValue;
+
+  /// An optional description for the server variable.
+  ///
+  /// CommonMark syntax MAY be used for rich text representation.
+  String? get description;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitServerVariable(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitServerVariable(this, arg);
+}
+
+final class OpenApiOperationType extends EnumClass {
+  const OpenApiOperationType._(super.name);
+
+  static const OpenApiOperationType get = _$get;
+  static const OpenApiOperationType put = _$put;
+  static const OpenApiOperationType post = _$post;
+  static const OpenApiOperationType delete = _$delete;
+  static const OpenApiOperationType options = _$options;
+  static const OpenApiOperationType head = _$head;
+  static const OpenApiOperationType patch = _$patch;
+  static const OpenApiOperationType trace = _$trace;
+
+  static BuiltSet<OpenApiOperationType> get values =>
+      _$OpenApiOperationTypeValues;
+  static OpenApiOperationType valueOf(String name) =>
+      _$OpenApiOperationTypeValueOf(name);
+}
+
+/// Holds the relative paths to the individual endpoints and their operations.
+///
+/// The path is appended to the URL from the Server Object in order to construct
+/// the full URL.
+///
+/// The Paths MAY be empty, due to Access Control List (ACL) constraints.
+///
+/// https://spec.openapis.org/oas/v3.1.0#path-item-object
+abstract class OpenApiPathItem
+    implements
+        Built<OpenApiPathItem, OpenApiPathItemBuilder>,
+        OpenApiComponent<OpenApiPathItem> {
+  factory OpenApiPathItem({
+    String? ref,
+    String? summary,
+    String? description,
+    Map<OpenApiOperationType, OpenApiOperation>? operations,
+    List<OpenApiComponentOrRef<OpenApiParameter>>? parameters,
+    List<OpenApiServer>? servers,
+  }) {
+    return _$OpenApiPathItem._(
+      ref: ref,
+      summary: summary,
+      description: description,
+      operations: (operations ?? const {}).build(),
+      parameters: (parameters ?? const []).build(),
+      servers: servers?.build(),
+    );
+  }
+
+  factory OpenApiPathItem.build(
+    void Function(OpenApiPathItemBuilder) updates,
+  ) = _$OpenApiPathItem;
+
+  OpenApiPathItem._();
+
+  /// An optional, string summary, intended to apply to all operations in this
+  /// path.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#path-item-object
+  @override
+  String? get summary;
+
+  /// An optional, string description, intended to apply to all operations in
+  /// this path.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#path-item-object
+  @override
+  String? get description;
+
+  /// A definition of the operations on this path.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#path-item-object
+  BuiltMap<OpenApiOperationType, OpenApiOperation> get operations;
+
+  /// An alternative server array to service all operations in this path.
+  BuiltList<OpenApiServer>? get servers;
+
+  /// A list of parameters that are applicable for all the operations described
+  /// under this path.
+  ///
+  /// These parameters can be overridden at the operation level, but cannot be
+  /// removed there. The list MUST NOT include duplicated parameters.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#path-item-object
+  BuiltList<OpenApiComponentOrRef<OpenApiParameter>> get parameters;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitPathItem(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitPathItem(this, arg);
+}
+
+/// Describes a single API operation on a path.
+///
+/// https://spec.openapis.org/oas/v3.1.0#operation-object
+abstract class OpenApiOperation
+    implements Built<OpenApiOperation, OpenApiOperationBuilder>, OpenApiNode {
+  factory OpenApiOperation({
+    required OpenApiOperationType type,
+    List<String>? tags,
+    String? summary,
+    String? description,
+    String? operationId,
+    List<OpenApiComponentOrRef<OpenApiParameter>>? parameters,
+    OpenApiComponentOrRef<OpenApiRequestBody>? requestBody,
+    OpenApiComponentOrRef<OpenApiResponse>? defaultResponse,
+    Map<StatusCodeOrRange, OpenApiComponentOrRef<OpenApiResponse>>? responses,
+    bool deprecated = false,
+    List<OpenApiServer>? servers,
+  }) {
+    return _$OpenApiOperation._(
+      type: type,
+      tags: (tags ?? const []).build(),
+      summary: summary,
+      description: description,
+      operationId: operationId,
+      parameters: (parameters ?? const []).build(),
+      requestBody: requestBody,
+      defaultResponse: defaultResponse,
+      responses: (responses ?? const {}).build(),
+      deprecated: deprecated,
+      servers: servers?.build(),
+    );
+  }
+
+  factory OpenApiOperation.build(
+    void Function(OpenApiOperationBuilder) updates,
+  ) = _$OpenApiOperation;
+
+  OpenApiOperation._();
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenApiOperationBuilder b) {
+    // TODO: this is wrong but refresh on what to do in edge cases here
+    // if (b._defaultResponse != null && b.responses.build().containsKey(200)) {
+    //   throw ArgumentError.value(
+    //     b,
+    //     'operation',
+    //     'Cannot have both a default response and a 200 response',
+    //   );
+    // }
+    b.deprecated ??= false;
+  }
+
+  /// REQUIRED. The type of the operation.
+  OpenApiOperationType get type;
+
+  /// A list of tags for API documentation control.
+  ///
+  /// Tags can be used for logical grouping of operations by resources or any
+  /// other qualifier.
+  BuiltList<String> get tags;
+
+  /// A short summary of what the operation does.
+  String? get summary;
+
+  /// A verbose explanation of the operation behavior.
+  ///
+  /// CommonMark syntax MAY be used for rich text representation.
+  String? get description;
+
+  /// Additional external documentation for this operation.
+  // final OpenApiExternalDocumentation? externalDocs;
+
+  /// A unique string used to identify the operation.
+  ///
+  /// The id MUST be unique among all operations described in the API. The
+  /// operationId value is case-sensitive. Tools and libraries MAY use the
+  /// operationId to uniquely identify an operation, therefore, it is
+  /// RECOMMENDED to follow common programming naming conventions.
+  String? get operationId;
+
+  /// A list of parameters that are applicable for this operation.
+  ///
+  /// If a parameter is already defined at the Path Item, the new definition
+  /// will override it but can never remove it.
+  ///
+  /// The list MUST NOT include duplicated parameters. A unique parameter is
+  /// defined by a combination of a `name` and `location`. The list can use the
+  /// Reference Object to link to parameters that are defined at the OpenAPI
+  /// Object's components/parameters.
+  BuiltList<OpenApiComponentOrRef<OpenApiParameter>> get parameters;
+
+  /// The request body applicable for this operation.
+  ///
+  /// The requestBody is only supported in HTTP methods where the HTTP 1.1
+  /// specification RFC7231 has explicitly defined semantics for request bodies.
+  ///
+  /// In other cases where the HTTP spec is vague (such as `GET`, `HEAD` and
+  /// `DELETE`), requestBody is permitted but does not have well-defined
+  /// semantics and SHOULD be avoided if possible.
+  OpenApiComponentOrRef<OpenApiRequestBody>? get requestBody;
+
+  /// {@template openapi_response}
+  /// A container for the expected responses of an operation.
+  ///
+  /// The container maps a HTTP response code to the expected response.
+  ///
+  /// The documentation is not necessarily expected to cover all possible HTTP
+  /// response codes because they may not be known in advance. However,
+  /// documentation is expected to cover a successful operation response and
+  /// any known errors.
+  ///
+  /// The default MAY be used as a default response object for all HTTP codes
+  /// that are not covered individually by the Responses Object.
+  ///
+  /// The Responses Object MUST contain at least one response code, and if only
+  /// one response code is provided it SHOULD be the response for a successful
+  /// operation call.
+  /// {@endtemplate}
+  BuiltMap<StatusCodeOrRange, OpenApiComponentOrRef<OpenApiResponse>>
+      get responses;
+
+  OpenApiComponentOrRef<OpenApiResponse>? get defaultResponse;
+
+  /// A map of possible out-of band callbacks related to the parent operation.
+  ///
+  /// Each value in the map is a Path Item Object that describes a set of
+  /// requests that may be initiated by the API provider and the expected
+  /// responses.
+  // final Map<String, OpenApiPathItem> callbacks;
+
+  /// Declares this operation to be deprecated.
+  ///
+  /// Consumers SHOULD refrain from usage of the declared operation.
+  bool get deprecated;
+
+  /// A declaration of which security mechanisms can be used for this operation.
+  ///
+  /// The list of values includes alternative security requirement objects that
+  /// can be used. Only one of the security requirement objects need to be
+  /// satisfied to authorize a request. To make security optional, an empty
+  /// security requirement ({}) can be included in the array.
+  ///
+  /// This definition overrides any declared top-level security. To remove a
+  /// top-level security declaration, an empty array can be used.
+  // final List<OpenApiSecurityRequirement> security;
+
+  /// An alternative server array to service this operation.
+  ///
+  /// If an alternative server object is specified at the Path Item Object or
+  /// Root level, it will be overridden by this value.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#operation-object
+  BuiltList<OpenApiServer>? get servers;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitOperation(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitOperation(this, arg);
+}
+
+@immutable
+sealed class StatusCodeOrRange {
+  static StatusCodeOrRange? tryParse(String statusCode) {
+    if (int.tryParse(statusCode) case final code?) {
+      return StatusCode(code);
+    }
+    if (_validRanges.firstMatch(statusCode) case final match?) {
+      return StatusCodeRange(int.parse(match.group(1)!));
+    }
+    return null;
+  }
+
+  static final _validRanges = RegExp(r'^([1-5])XX$');
+}
+
+final class StatusCode implements StatusCodeOrRange {
+  const StatusCode(this.code);
+
+  final int code;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) || other is StatusCode && other.code == code;
+  }
+
+  @override
+  int get hashCode => code.hashCode;
+
+  @override
+  String toString() => code.toString();
+}
+
+final class StatusCodeRange implements StatusCodeOrRange {
+  const StatusCodeRange(this.group);
+
+  final int group; // e.g. 4, 5
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is StatusCodeRange && other.group == group;
+  }
+
+  @override
+  int get hashCode => group.hashCode;
+
+  @override
+  String toString() => '${group}XX';
+}
+
+final class OpenApiParameterLocation extends EnumClass {
+  const OpenApiParameterLocation._(super.name);
+
+  static const OpenApiParameterLocation query = _$query;
+  static const OpenApiParameterLocation header = _$header;
+  static const OpenApiParameterLocation path = _$path;
+  static const OpenApiParameterLocation cookie = _$cookie;
+
+  static BuiltSet<OpenApiParameterLocation> get values =>
+      _$OpenApiParameterLocationValues;
+  static OpenApiParameterLocation valueOf(String name) =>
+      _$OpenApiParameterLocationValueOf(name);
+}
+
+/// In order to support common ways of serializing simple parameters, a set of
+/// style values are defined.
+///
+/// https://spec.openapis.org/oas/v3.1.0#style-values
+final class OpenApiParameterStyle extends EnumClass {
+  const OpenApiParameterStyle._(super.name);
+
+  /// Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570).
+  ///
+  /// - Valid for `path` parameters.
+  /// - Valid for types: `primitive`, `array`, `object`.
+  static const OpenApiParameterStyle matrix = _$matrix;
+
+  /// Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570).
+  ///
+  /// - Valid for `path` parameters.
+  /// - Valid for types: `primitive`, `array`, `object`.
+  static const OpenApiParameterStyle label = _$label;
+
+  /// Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570).
+  ///
+  /// This option replaces `collectionFormat` with a `csv` (when explode is
+  /// `false`) or `multi` (when `explode` is true) value from OpenAPI 2.0.
+  ///
+  /// - Valid for parameters: `query`, `cookie`.
+  /// - Valid for types: `primitive`, `array`, `object`.
+  static const OpenApiParameterStyle form = _$form;
+
+  /// Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570).
+  ///
+  /// This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
+  ///
+  /// - Valid for parameters: `path`, `header`.
+  /// - Valid for types: `array`.
+  static const OpenApiParameterStyle simple = _$simple;
+
+  /// Space separated array or object values.
+  ///
+  /// This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0.
+  ///
+  /// - Valid for parameters: `query`.
+  /// - Valid for types: `array`, `object`.
+  static const OpenApiParameterStyle spaceDelimited = _$spaceDelimited;
+
+  /// Pipe separated array or object values.
+  ///
+  /// This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
+  ///
+  /// - Valid for parameters: `query`.
+  /// - Valid for types: `array`, `object`.
+  static const OpenApiParameterStyle pipeDelimited = _$pipeDelimited;
+
+  /// Provides a simple way of rendering nested objects using form parameters.
+  ///
+  /// Objects with properties of simple types are rendered as if they were
+  /// query parameters.
+  ///
+  /// - Valid for parameters: `query`.
+  /// - Valid for types: `object`.
+  static const OpenApiParameterStyle deepObject = _$deepObject;
+
+  static BuiltSet<OpenApiParameterStyle> get values =>
+      _$OpenApiParameterStyleValues;
+  static OpenApiParameterStyle valueOf(String name) =>
+      _$OpenApiParameterStyleValueOf(name);
+}
+
+/// Describes a single operation parameter.
+///
+/// A unique parameter is defined by a combination of a [name] and [location].
+///
+/// https://spec.openapis.org/oas/v3.1.0#parameter-object
+abstract class OpenApiParameter
+    implements
+        Built<OpenApiParameter, OpenApiParameterBuilder>,
+        OpenApiComponent<OpenApiParameter> {
+  factory OpenApiParameter({
+    required String name,
+    required OpenApiParameterLocation location,
+    String? description,
+    bool required = false,
+    bool deprecated = false,
+    bool allowEmptyValue = false,
+    OpenApiParameterStyle? style,
+    bool? explode,
+    bool? allowReserved,
+    OpenApiComponentOrRef<OpenApiSchema>? schema,
+    // Map<String, OpenApiExample> examples = const {},
+    // TODO: Or media type range.
+    (MediaType, OpenApiMediaType)? content,
+  }) {
+    return _$OpenApiParameter._(
+      name: name,
+      location: location,
+      description: description,
+      required: required,
+      deprecated: deprecated,
+      allowEmptyValue: allowEmptyValue,
+      style: style,
+      explode: explode,
+      allowReserved: allowReserved,
+      schema: schema,
+      // examples: examples.build(),
+      content: content,
+    );
+  }
+
+  factory OpenApiParameter.build(
+    void Function(OpenApiParameterBuilder) updates,
+  ) = _$OpenApiParameter;
+
+  OpenApiParameter._();
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenApiParameterBuilder b) {
+    // For more complex scenarios, the content property can define the media type
+    // and schema of the parameter. A parameter MUST contain either a schema
+    // property, or a content property, but not both. When example or examples
+    // are provided in conjunction with the schema object, the example MUST follow
+    // the prescribed serialization strategy for the parameter.
+    //
+    // https://spec.openapis.org/oas/v3.1.0#parameter-object
+    if (b._schema != null && b.content != null ||
+        b._schema == null && b.content == null) {
+      throw ArgumentError.value(
+        b,
+        'parameter',
+        'Exactly one of schema or content must be set',
+      );
+    }
+    b
+      ..required ??= false
+      ..deprecated ??= false
+      ..allowEmptyValue ??= false;
+  }
+
+  /// REQUIRED. The name of the parameter.
+  ///
+  /// Parameter names are case sensitive.
+  ///
+  /// - If [location] is `path`, the [name] field MUST correspond to a template
+  ///   expression occurring within a [OpenApiPathItem] key.
+  ///
+  /// - If [location] is `header` and the [name] field is `Accept`, `Content-Type`
+  ///   or `Authorization`, the parameter definition SHALL be ignored.
+  ///
+  /// - For all other cases, the [name] corresponds to the parameter name used
+  ///   by the in property.
+  String get name;
+
+  /// REQUIRED. The location of the parameter.
+  OpenApiParameterLocation get location;
+
+  /// A brief description of the parameter.
+  ///
+  /// This could contain examples of use. CommonMark syntax MAY be used for
+  /// rich text representation.
+  @override
+  String? get description;
+
+  /// Determines whether this parameter is mandatory.
+  ///
+  /// If the parameter location is "path", this property is REQUIRED and its
+  /// value MUST be `true`. Otherwise, the property MAY be included and its
+  /// default value is `false`.
+  bool get required;
+
+  /// Specifies that a parameter is deprecated and SHOULD be transitioned out
+  /// of usage.
+  bool get deprecated;
+
+  /// Sets the ability to pass empty-valued parameters.
+  ///
+  /// This is valid only for query parameters and allows sending a parameter
+  /// with an empty value.
+  ///
+  /// Default value is false.
+  bool get allowEmptyValue;
+
+  /// Describes how the parameter value will be serialized depending on the
+  /// type of the parameter value.
+  ///
+  /// Default values (based on value of in):
+  /// - for query: form
+  /// - for path: simple
+  /// - for header: simple
+  /// - for cookie: form
+  OpenApiParameterStyle? get style;
+
+  /// When this is true, parameter values of type `array` or `object` generate
+  /// separate parameters for each value of the array or key-value pair of the
+  /// map.
+  ///
+  /// For other types of parameters this property has no effect. When [style] is
+  /// `form`, the default value is `true`. For all other styles, the default value
+  /// is `false`.
+  bool? get explode;
+
+  /// Determines whether the parameter value SHOULD allow reserved characters,
+  /// as defined by [RFC3986](https://tools.ietf.org/html/rfc3986).
+  ///
+  /// This property only applies to parameters with a location of query. The
+  /// default value is false.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#parameter-object
+  bool? get allowReserved;
+
+  /// The schema defining the type used for the parameter.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#parameter-object
+  OpenApiComponentOrRef<OpenApiSchema>? get schema;
+
+  /// Examples of the media type.
+  ///
+  /// Each example object SHOULD match the media type and specified schema if
+  /// present.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#parameter-object
+  // final Map<String, OpenApiExample> examples;
+
+  /// A map containing the representations for the parameter.
+  ///
+  /// The key is the media type and the value describes it. The map MUST only
+  /// contain one entry.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#parameter-object
+  // TODO: Or media type range.
+  (MediaType, OpenApiMediaType)? get content;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitParameter(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitParameter(this, arg);
+}
+
+/// Each Media Type Object provides schema and examples for the media type identified by its key.
+///
+/// https://spec.openapis.org/oas/v3.1.0#media-type-object
+abstract class OpenApiMediaType
+    implements Built<OpenApiMediaType, OpenApiMediaTypeBuilder>, OpenApiNode {
+  factory OpenApiMediaType({
+    required OpenApiComponentOrRef<OpenApiSchema> schema,
+    // Map<String, OpenApiExample> examples = const {},
+    Map<String, OpenApiEncoding>? encoding,
+  }) {
+    return _$OpenApiMediaType._(
+      schema: schema,
+      // examples: examples.build(),
+      encoding: (encoding ?? {}).build(),
+    );
+  }
+
+  factory OpenApiMediaType.build(
+    void Function(OpenApiMediaTypeBuilder) updates,
+  ) = _$OpenApiMediaType;
+
+  OpenApiMediaType._();
+
+  /// The schema defining the content of the request, response, or parameter.
+  OpenApiComponentOrRef<OpenApiSchema> get schema;
+
+  /// Examples of the media type.
+  ///
+  /// Each example object SHOULD match the media type and specified schema if
+  /// present.
+  // final Map<String, OpenApiExample> examples;
+
+  /// A map between a property name and its encoding information.
+  ///
+  /// The key, being the property name, MUST exist in the schema as a property.
+  /// The encoding object SHALL only apply to [OpenApiOperation.requestBody]
+  /// objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
+  BuiltMap<String, OpenApiEncoding> get encoding;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitMediaType(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitMediaType(this, arg);
+}
+
+/// Describes a single request body.
+///
+/// https://spec.openapis.org/oas/v3.1.0#request-body-object
+abstract class OpenApiRequestBody
+    implements
+        Built<OpenApiRequestBody, OpenApiRequestBodyBuilder>,
+        OpenApiComponent<OpenApiRequestBody> {
+  factory OpenApiRequestBody({
+    // TODO: Or media type range.
+    required Map<MediaType, OpenApiMediaType> content,
+    String? description,
+    bool required = false,
+  }) {
+    return _$OpenApiRequestBody._(
+      content: content.build(),
+      description: description,
+      required: required,
+    );
+  }
+
+  factory OpenApiRequestBody.build(
+    void Function(OpenApiRequestBodyBuilder) updates,
+  ) = _$OpenApiRequestBody;
+
+  OpenApiRequestBody._();
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenApiRequestBodyBuilder b) {
+    if (b.content.isEmpty) {
+      throw ArgumentError.value(
+        b,
+        'requestBody',
+        'At least one content type must be provided',
+      );
+    }
+    b.required ??= false;
+  }
+
+  /// REQUIRED. The content of the request body.
+  ///
+  /// The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D)
+  /// and the value describes it.
+  ///
+  /// For requests that match multiple keys, only the most specific key is
+  /// applicable. e.g. `text/plain` overrides `text/*`.
+  // TODO: Or media type range.
+  BuiltMap<MediaType, OpenApiMediaType> get content;
+
+  /// A brief description of the request body.
+  ///
+  /// This could contain examples of use. CommonMark syntax MAY be used for
+  /// rich text representation.
+  @override
+  String? get description;
+
+  /// Determines if the request body is required in the request.
+  ///
+  /// Defaults to `false`.
+  bool get required;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitRequestBody(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitRequestBody(this, arg);
+}
+
+/// A single encoding definition applied to a single schema property.
+///
+/// https://spec.openapis.org/oas/v3.1.0#encoding-object
+abstract class OpenApiEncoding
+    implements Built<OpenApiEncoding, OpenApiEncodingBuilder>, OpenApiNode {
+  factory OpenApiEncoding({
+    required MediaType contentType,
+    Map<String, OpenApiComponentOrRef<OpenApiHeader>> headers = const {},
+    OpenApiParameterStyle? style,
+    bool? explode,
+    bool allowReserved = false,
+  }) {
+    return _$OpenApiEncoding._(
+      contentType: contentType,
+      headers: headers.build(),
+      style: style,
+      explode: explode ??
+          switch (style) {
+            OpenApiParameterStyle.form => true,
+            _ => false,
+          },
+      allowReserved: allowReserved,
+    );
+  }
+
+  factory OpenApiEncoding.build(
+    void Function(OpenApiEncodingBuilder) updates,
+  ) = _$OpenApiEncoding;
+
+  OpenApiEncoding._();
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenApiEncodingBuilder b) {
+    b.allowReserved ??= false;
+  }
+
+  /// The Content-Type for encoding a specific property.
+  ///
+  /// Default value depends on the property type: for `string` with `format`
+  /// being `binary` – `application/octet-stream`; for other primitive types –
+  /// `application/json`; for `object` – `application/json`; for `array` – the
+  /// default is defined based on the inner type. The value can be a specific
+  /// media type (e.g. `application/json`), a wildcard media type (e.g. `image/*`),
+  /// or a comma-separated list of the two types.
+  MediaType get contentType;
+
+  /// A map allowing additional information to be provided as headers, for
+  /// example `Content-Disposition`. Content-Type is described separately and
+  /// SHALL be ignored in this section. This property SHALL be ignored if the
+  /// request body media type is not `multipart` or `application/x-www-form-urlencoded`.
+  BuiltMap<String, OpenApiComponentOrRef<OpenApiHeader>> get headers;
+
+  /// Describes how a specific property value will be serialized depending on
+  /// its type.
+  ///
+  /// This property SHALL be ignored if the request body media type is not
+  /// `application/x-www-form-urlencoded` or `multipart/form-data`. If a value
+  /// is explicitly defined, then the value of contentType (implicit or explicit)
+  /// SHALL be ignored.
+  OpenApiParameterStyle? get style;
+
+  /// When this is true, property values of type `array` or `object` generate
+  /// separate parameters for each value of the array, or key-value pair of the
+  /// map.
+  ///
+  /// For other types of properties this property has no effect.
+  ///
+  /// When [style] is `form`, the default value is `true`. For all other styles,
+  /// the default value is `false`.
+  bool get explode;
+
+  /// Determines whether the parameter value SHOULD allow reserved characters,
+  /// as defined by [RFC3986](https://tools.ietf.org/html/rfc3986): `:/?#[]@!$&'()*+,;=`
+  ///
+  /// This property SHALL be ignored if the request body media type is not
+  /// `application/x-www-form-urlencoded` or `multipart/form-data`. If a value
+  /// is explicitly defined, then the value of [contentType] (implicit or
+  /// explicit) SHALL be ignored.
+  bool get allowReserved;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitEncoding(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitEncoding(this, arg);
+}
+
+/// {@macro openapi_response}
+///
+/// https://spec.openapis.org/oas/v3.1.0#responses-object
+abstract class OpenApiResponse
+    implements
+        Built<OpenApiResponse, OpenApiResponseBuilder>,
+        OpenApiComponent<OpenApiResponse> {
+  factory OpenApiResponse({
+    required StatusCodeOrRange? statusCode,
+    required String description,
+    Map<String, OpenApiComponentOrRef<OpenApiHeader>>? headers,
+    Map<MediaType, OpenApiMediaType>? content,
+    // Map<String, OpenApiLink> links = const {},
+  }) {
+    return _$OpenApiResponse._(
+      statusCode: statusCode,
+      description: description,
+      headers: (headers ?? const {}).build(),
+      content: (content ?? const {}).build(),
+      // links: links,
+    );
+  }
+
+  factory OpenApiResponse.build(
+    void Function(OpenApiResponseBuilder) updates,
+  ) = _$OpenApiResponse;
+
+  OpenApiResponse._();
+
+  StatusCodeOrRange? get statusCode;
+
+  /// REQUIRED. A short description of the response.
+  ///
+  /// CommonMark syntax MAY be used for rich text representation.
+  @override
+  String get description;
+
+  /// Maps a header name to its definition.
+  ///
+  /// [RFC7230](https://tools.ietf.org/html/rfc7230) states header names are
+  /// case insensitive. If a response header is defined with the name
+  /// "Content-Type", it SHALL be ignored.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#responses-object
+  BuiltMap<String, OpenApiComponentOrRef<OpenApiHeader>> get headers;
+
+  /// A map containing descriptions of potential response payloads.
+  ///
+  /// The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D)
+  /// and the value describes it. For responses that match multiple keys, only
+  /// the most specific key is applicable. e.g. `text/plain` overrides `text/*`.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#responses-object
+  BuiltMap<MediaType, OpenApiMediaType> get content;
+
+  /// A map of operations links that can be followed from the response.
+  ///
+  /// The key of the map is a short name for the link, following the naming
+  /// constraints of the names for Component Objects.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#responses-object
+  // final Map<String, OpenApiLink> links;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitResponse(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitResponse(this, arg);
+}
+
+/// The Header Object follows the structure of the Parameter Object with the following changes:
+///
+/// 1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.
+/// 2. `in` MUST NOT be specified, it is implicitly in `header`.
+/// 3. All traits that are affected by the location MUST be applicable to a location of `header` (for example, `style`).
+///
+/// https://spec.openapis.org/oas/v3.1.0#header-object
+abstract class OpenApiHeader
+    implements
+        Built<OpenApiHeader, OpenApiHeaderBuilder>,
+        OpenApiComponent<OpenApiHeader> {
+  factory OpenApiHeader({
+    required OpenApiComponentOrRef<OpenApiSchema> schema,
+    String? description,
+    bool required = false,
+    bool deprecated = false,
+    bool allowEmptyValue = false,
+    OpenApiParameterStyle? style,
+    bool? explode,
+    bool? allowReserved,
+    (MediaType, OpenApiMediaType)? content,
+  }) {
+    return _$OpenApiHeader._(
+      schema: schema,
+      description: description,
+      required: required,
+      deprecated: deprecated,
+      allowEmptyValue: allowEmptyValue,
+      style: style,
+      explode: explode,
+      allowReserved: allowReserved,
+      content: content,
+    );
+  }
+
+  factory OpenApiHeader.build(
+    void Function(OpenApiHeaderBuilder) updates,
+  ) = _$OpenApiHeader;
+
+  OpenApiHeader._();
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenApiHeaderBuilder b) {
+    b
+      ..required ??= false
+      ..deprecated ??= false
+      ..allowEmptyValue ??= false;
+  }
+
+  /// The schema defining the type used for the parameter.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#parameter-object
+  OpenApiComponentOrRef<OpenApiSchema> get schema;
+
+  /// A brief description of the parameter.
+  ///
+  /// This could contain examples of use. CommonMark syntax MAY be used for
+  /// rich text representation.
+  @override
+  String? get description;
+
+  /// Determines whether this parameter is mandatory.
+  ///
+  /// If the parameter location is "path", this property is REQUIRED and its
+  /// value MUST be `true`. Otherwise, the property MAY be included and its
+  /// default value is `false`.
+  bool get required;
+
+  /// Specifies that a parameter is deprecated and SHOULD be transitioned out
+  /// of usage.
+  bool get deprecated;
+
+  /// Sets the ability to pass empty-valued parameters.
+  ///
+  /// This is valid only for query parameters and allows sending a parameter
+  /// with an empty value.
+  ///
+  /// Default value is false.
+  bool get allowEmptyValue;
+
+  /// Describes how the parameter value will be serialized depending on the
+  /// type of the parameter value.
+  ///
+  /// Default values (based on value of in):
+  /// - for query: form
+  /// - for path: simple
+  /// - for header: simple
+  /// - for cookie: form
+  OpenApiParameterStyle? get style;
+
+  /// When this is true, parameter values of type `array` or `object` generate
+  /// separate parameters for each value of the array or key-value pair of the
+  /// map.
+  ///
+  /// For other types of parameters this property has no effect. When [style] is
+  /// `form`, the default value is `true`. For all other styles, the default value
+  /// is `false`.
+  bool? get explode;
+
+  /// Determines whether the parameter value SHOULD allow reserved characters,
+  /// as defined by [RFC3986](https://tools.ietf.org/html/rfc3986).
+  ///
+  /// This property only applies to parameters with a location of query. The
+  /// default value is false.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#parameter-object
+  bool? get allowReserved;
+
+  /// A map containing the representations for the parameter.
+  ///
+  /// The key is the media type and the value describes it. The map MUST only
+  /// contain one entry.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#parameter-object
+  (MediaType, OpenApiMediaType)? get content;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitHeader(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitHeader(this, arg);
+}
+
+/// Holds a set of reusable objects for different aspects of the OAS.
+///
+/// All objects defined within the components object will have no effect on the
+/// API unless they are explicitly referenced from properties outside the
+/// components object.
+///
+/// All the fixed fields of objects that MUST use keys that match the regular
+/// expression: `^[a-zA-Z0-9\.\-_]+$`
+///
+/// https://spec.openapis.org/oas/v3.1.0#components-object
+abstract class OpenApiComponents
+    implements Built<OpenApiComponents, OpenApiComponentsBuilder>, OpenApiNode {
+  factory OpenApiComponents({
+    Map<String, OpenApiSchema>? schemas,
+    Map<String, OpenApiResponse>? responses,
+    Map<String, OpenApiParameter>? parameters,
+    // Map<String, OpenApiExample> examples = const {},
+    Map<String, OpenApiRequestBody>? requestBodies,
+    Map<String, OpenApiHeader>? headers,
+    Map<String, OpenApiSecurityScheme> securitySchemes = const {},
+    // Map<String, OpenApiLink> links = const {},
+    // Map<String, OpenApiPathItem> callbacks = const {},
+    Map<String, OpenApiPathItem>? paths,
+  }) {
+    return _$OpenApiComponents._(
+      schemas: (schemas ?? {}).build(),
+      responses: (responses ?? {}).build(),
+      parameters: (parameters ?? {}).build(),
+      // examples: examples.build(),
+      requestBodies: (requestBodies ?? {}).build(),
+      headers: (headers ?? {}).build(),
+      securitySchemes: securitySchemes.build(),
+      // links: links.build(),
+      // callbacks: callbacks.build(),
+      paths: (paths ?? {}).build(),
+    );
+  }
+
+  factory OpenApiComponents.build(
+    void Function(OpenApiComponentsBuilder) updates,
+  ) = _$OpenApiComponents;
+
+  OpenApiComponents._();
+
+  /// An object to hold reusable Schema Objects.
+  BuiltMap<String, OpenApiSchema> get schemas;
+
+  /// An object to hold reusable Response Objects.
+  BuiltMap<String, OpenApiResponse> get responses;
+
+  /// An object to hold reusable Parameter Objects.
+  BuiltMap<String, OpenApiParameter> get parameters;
+
+  /// An object to hold reusable Example Objects.
+  // final Map<String, OpenApiExample> examples;
+
+  /// An object to hold reusable Request Body Objects.
+  BuiltMap<String, OpenApiRequestBody> get requestBodies;
+
+  /// An object to hold reusable Header Objects.
+  BuiltMap<String, OpenApiHeader> get headers;
+
+  /// An object to hold reusable Security Scheme Objects.
+  BuiltMap<String, OpenApiSecurityScheme> get securitySchemes;
+
+  /// An object to hold reusable Link Objects.
+  // final Map<String, OpenApiLink> links;
+
+  /// An object to hold reusable Callback Objects.
+  // final Map<String, OpenApiPathItem> callbacks;
+
+  /// An object to hold reusable Path Item Object.
+  BuiltMap<String, OpenApiPathItem> get paths;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitComponents(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitComponents(this, arg);
+}
+
+@immutable
+sealed class ItemOrList<T extends Object> {
+  T? get value;
+}
+
+final class ItemValue<T extends Object> implements ItemOrList<T> {
+  const ItemValue(this.value);
+
+  @override
+  final T value;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) || other is ItemValue && other.value == value;
+  }
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => value.toString();
+}
+
+final class ItemList<T extends Object> extends DelegatingList<T>
+    implements ItemOrList<T> {
+  const ItemList(super.base);
+
+  @override
+  T? get value => null;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is ItemList<T> && ListEquality<T>().equals(this, other);
+  }
+
+  @override
+  int get hashCode => ListEquality<T>().hash(this);
+
+  @override
+  String toString() => '[${join(', ')}]';
+}
+
+/// The Schema Object allows the definition of input and output data types.
+///
+/// These types can be objects, but also primitives and arrays. This object is
+/// a superset of the JSON Schema Specification Draft 2020-12.
+///
+/// For more information about the properties, see JSON Schema Core and JSON
+/// Schema Validation.
+///
+/// Unless stated otherwise, the property definitions follow those of JSON
+/// Schema and do not add any additional semantics. Where JSON Schema indicates
+/// that behavior is defined by the application (e.g. for annotations), OAS
+/// also defers the definition of semantics to the application consuming the
+/// OpenAPI document.
+///
+/// https://spec.openapis.org/oas/v3.1.0#schema-object
+abstract class OpenApiSchema
+    implements
+        Built<OpenApiSchema, OpenApiSchemaBuilder>,
+        OpenApiComponent<OpenApiSchema> {
+  factory OpenApiSchema({
+    String? ref,
+    YamlNode? node,
+    String? name,
+    String? title,
+    String? description,
+    ItemOrList<JsonType>? type,
+    bool? nullable,
+    Iterable<OpenApiComponentOrRef<OpenApiSchema>>? allOf,
+    Iterable<OpenApiComponentOrRef<OpenApiSchema>>? oneOf,
+    Iterable<OpenApiComponentOrRef<OpenApiSchema>>? anyOf,
+    // required OpenApiComponentOrRef<OpenApiSchema>? not,
+    OpenApiComponentOrRef<OpenApiSchema>? items,
+    int? maxItems,
+    int? minItems,
+    bool? uniqueItems,
+    Map<String, OpenApiComponentOrRef<OpenApiSchema>>? properties,
+    OpenApiAdditionalProperties? additionalProperties,
+    int? maxProperties,
+    int? minProperties,
+    Iterable<String>? required,
+    JsonTypeFormat? format,
+    Object? defaultValue,
+    num? multipleOf,
+    num? maximum,
+    bool? exclusiveMaximum,
+    num? minimum,
+    bool? exclusiveMinimum,
+    int? maxLength,
+    int? minLength,
+    String? pattern,
+    Iterable<Object?>? enumValues,
+    bool? deprecated,
+    bool? readOnly,
+    bool? writeOnly,
+    OpenApiDiscriminator? discriminator,
+    Map<String, Object?>? extensions,
+  }) {
+    return _$OpenApiSchema._(
+      ref: ref,
+      node: node,
+      name: name,
+      title: title,
+      description: description,
+      type: type,
+      nullable: nullable,
+      allOf: allOf?.toBuiltList(),
+      oneOf: oneOf?.toBuiltList(),
+      anyOf: anyOf?.toBuiltList(),
+      // not: not,
+      items: items,
+      maxItems: maxItems,
+      minItems: minItems,
+      uniqueItems: uniqueItems,
+      properties: properties?.build(),
+      additionalProperties: additionalProperties,
+      maxProperties: maxProperties,
+      minProperties: minProperties,
+      required: required?.toBuiltSet(),
+      format: format,
+      defaultValue: defaultValue,
+      multipleOf: multipleOf,
+      maximum: maximum,
+      exclusiveMaximum: exclusiveMaximum,
+      minimum: minimum,
+      exclusiveMinimum: exclusiveMinimum,
+      maxLength: maxLength,
+      minLength: minLength,
+      pattern: pattern,
+      enumValues: enumValues?.toBuiltSet(),
+      deprecated: deprecated,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      discriminator: discriminator,
+      extensions: extensions?.map((k, v) => MapEntry(k, JsonObject(v))).build(),
+    );
+  }
+
+  factory OpenApiSchema.build(
+    void Function(OpenApiSchemaBuilder) updates,
+  ) = _$OpenApiSchema;
+
+  OpenApiSchema._();
+
+  /// The intrinsic name of the type, if any.
+  ///
+  /// This is the exact value from the source YAML and is not suitable for use
+  /// in Dart representations, unlike [name].
+  String? get name;
+
+  /// The value of this keyword MUST be either a string or an array. If it is
+  /// an array, elements of the array MUST be strings and MUST be unique.
+  ///
+  /// String values MUST be one of the six primitive types ("null", "boolean",
+  /// "object", "array", "number", or "string"), or "integer" which matches any
+  /// number with a zero fractional part.
+  ///
+  /// If the value of "type" is a string, then an instance validates
+  /// successfully if its type matches the type represented by the value of the
+  /// string. If the value of "type" is an array, then an instance validates
+  /// successfully if its type matches any of the types indicated by the strings
+  /// in the array.
+  ///
+  /// https://json-schema.org/draft/2020-12/json-schema-validation#name-type
+  ItemOrList<JsonType>? get type;
+
+  bool? get nullable;
+
+  BuiltList<OpenApiComponentOrRef<OpenApiSchema>>? get allOf;
+
+  BuiltList<OpenApiComponentOrRef<OpenApiSchema>>? get oneOf;
+
+  BuiltList<OpenApiComponentOrRef<OpenApiSchema>>? get anyOf;
+
+  // OpenApiComponentOrRef<OpenApiSchema>? get not;
+
+  OpenApiComponentOrRef<OpenApiSchema>? get items;
+
+  int? get maxItems;
+
+  int? get minItems;
+
+  bool? get uniqueItems;
+
+  BuiltMap<String, OpenApiComponentOrRef<OpenApiSchema>>? get properties;
+
+  OpenApiAdditionalProperties? get additionalProperties;
+
+  int? get maxProperties;
+
+  int? get minProperties;
+
+  /// The list of required properties, if any.
+  ///
+  /// The value of this keyword MUST be an array. Elements of this array, if
+  /// any, MUST be strings, and MUST be unique.
+  ///
+  /// An object instance is valid against this keyword if every item in the
+  /// array is the name of a property in the instance.
+  ///
+  /// Omitting this keyword has the same behavior as an empty array.
+  ///
+  /// https://json-schema.org/draft/2020-12/json-schema-validation#name-required
+  BuiltSet<String>? get required;
+
+  JsonTypeFormat? get format;
+
+  num? get multipleOf;
+
+  num? get maximum;
+
+  bool? get exclusiveMaximum;
+
+  num? get minimum;
+
+  bool? get exclusiveMinimum;
+
+  int? get maxLength;
+
+  int? get minLength;
+
+  String? get pattern;
+
+  /// The value of this keyword MUST be an array. This array SHOULD have at
+  /// least one element. Elements in the array SHOULD be unique.
+  ///
+  /// An instance validates successfully against this keyword if its value is
+  /// equal to one of the elements in this keyword's array value.
+  ///
+  /// Elements in the array might be of any type, including `null`.
+  ///
+  /// https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2
+  BuiltSet<Object?>? get enumValues;
+
+  // const
+  // https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.3
+
+  /// Adds support for polymorphism.
+  ///
+  /// The discriminator is an object name that is used to differentiate between
+  /// other schemas which may satisfy the payload description.
+  ///
+  /// See Composition and Inheritance for more details.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#schema-object
+  OpenApiDiscriminator? get discriminator;
+
+  // xml
+  // externalDocs
+  // example
+
+  /// Both [title] and [description] can be used to decorate a user interface
+  /// with information about the data produced by this user interface. A title
+  /// will preferably be short, whereas a description will provide explanation
+  /// about the purpose of the instance described by this schema.
+  ///
+  /// https://json-schema.org/draft/2020-12/json-schema-validation#name-title-and-description
+  String? get title;
+
+  /// CommonMark syntax MAY be used for rich text representation.
+  @override
+  String? get description;
+
+  /// Specifies that a schema is deprecated and SHOULD be transitioned out of usage.
+  bool? get deprecated;
+
+  /// This keyword can be used to supply a default JSON value associated with a
+  /// particular schema.
+  ///
+  /// It is RECOMMENDED that a default value be valid against the associated
+  /// schema.
+  ///
+  /// https://json-schema.org/draft/2020-12/json-schema-validation#name-default
+  Object? get defaultValue;
+
+  /// If "readOnly" has a value of boolean true, it indicates that the value of
+  /// the instance is managed exclusively by the owning authority, and attempts
+  /// by an application to modify the value of this property are expected to be
+  /// ignored or rejected by that owning authority.
+  ///
+  /// An instance document that is marked as "readOnly" for the entire document
+  /// MAY be ignored if sent to the owning authority, or MAY result in an error,
+  /// at the authority's discretion.
+  ///
+  /// These keywords can be used to assist in user interface instance
+  /// generation. In particular, an application MAY choose to use a widget that
+  /// hides input values as they are typed for write-only fields.
+  ///
+  /// https://json-schema.org/draft/2020-12/json-schema-validation#name-readonly-and-writeonly
+  bool? get readOnly;
+
+  /// If "writeOnly" has a value of boolean true, it indicates that the value is
+  /// never present when the instance is retrieved from the owning authority. It
+  /// can be present when sent to the owning authority to update or create the
+  /// document (or the resource it represents), but it will not be included in
+  /// any updated or newly created version of the instance.
+  ///
+  /// An instance document that is marked as "writeOnly" for the entire document
+  /// MAY be returned as a blank document of some sort, or MAY produce an error
+  /// upon retrieval, or have the retrieval request ignored, at the authority's
+  /// discretion.
+  ///
+  /// For example, "readOnly" would be used to mark a database-generated serial
+  /// number as read-only, while "writeOnly" would be used to mark a password
+  /// input field.
+  ///
+  /// These keywords can be used to assist in user interface instance
+  /// generation. In particular, an application MAY choose to use a widget that
+  /// hides input values as they are typed for write-only fields.
+  ///
+  /// https://json-schema.org/draft/2020-12/json-schema-validation#name-readonly-and-writeonly
+  bool? get writeOnly;
+
+  BuiltMap<String, JsonObject>? get extensions;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitSchema(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitSchema(this, arg);
+}
+
+abstract class OpenApiAdditionalProperties
+    implements
+        Built<OpenApiAdditionalProperties, OpenApiAdditionalPropertiesBuilder>,
+        OpenApiNode {
+  factory OpenApiAdditionalProperties({
+    bool? allow,
+    OpenApiComponentOrRef<OpenApiSchema>? schema,
+  }) {
+    assert(
+      allow != null || schema != null,
+      'Either allow or schema must be provided',
+    );
+    return _$OpenApiAdditionalProperties._(
+      allow: allow,
+      schema: schema,
+    );
+  }
+
+  factory OpenApiAdditionalProperties.build([
+    void Function(OpenApiAdditionalPropertiesBuilder) updates,
+  ]) = _$OpenApiAdditionalProperties;
+
+  OpenApiAdditionalProperties._();
+
+  bool? get allow;
+
+  OpenApiComponentOrRef<OpenApiSchema>? get schema;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) =>
+      visitor.visitAdditionalProperties(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitAdditionalProperties(this, arg);
+}
+
+/// When request bodies or response payloads may be one of a number of different
+/// schemas, a discriminator object can be used to aid in serialization,
+/// deserialization, and validation.
+///
+/// The discriminator is a specific object in a schema which is used to inform
+/// the consumer of the document of an alternative schema based on the value
+/// associated with it.
+///
+/// When using the discriminator, inline schemas will not be considered.
+///
+/// https://spec.openapis.org/oas/v3.1.0#discriminator-object
+abstract class OpenApiDiscriminator
+    implements
+        Built<OpenApiDiscriminator, OpenApiDiscriminatorBuilder>,
+        OpenApiNode {
+  factory OpenApiDiscriminator({
+    required String propertyName,
+    Map<String, String>? mapping,
+    String? ref,
+    YamlNode? node,
+  }) {
+    return _$OpenApiDiscriminator._(
+      ref: ref,
+      node: node,
+      propertyName: propertyName,
+      mapping: mapping?.build(),
+    );
+  }
+
+  factory OpenApiDiscriminator.build(
+    void Function(OpenApiDiscriminatorBuilder) updates,
+  ) = _$OpenApiDiscriminator;
+
+  OpenApiDiscriminator._();
+
+  /// REQUIRED. The name of the property in the payload that will hold the
+  /// discriminator value.
+  String get propertyName;
+
+  /// An object to hold mappings between payload values and schema names or
+  /// references.
+  ///
+  /// https://spec.openapis.org/oas/v3.1.0#discriminator-object
+  BuiltMap<String, String>? get mapping;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitDiscriminator(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitDiscriminator(this, arg);
+}
+
+/// Defines a security scheme that can be used by the operations.
+///
+/// Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter),
+/// OAuth2's common flows (implicit, password, client credentials and authorization code) as defined in RFC6749,
+/// and OpenID Connect Discovery.
+///
+/// https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+abstract class OpenApiSecurityScheme
+    implements
+        Built<OpenApiSecurityScheme, OpenApiSecuritySchemeBuilder>,
+        OpenApiComponent<OpenApiSecurityScheme> {
+  factory OpenApiSecurityScheme({
+    required OpenApiSecuritySchemeType type,
+    String? description,
+    String? name,
+    OpenApiParameterLocation? location,
+    String? scheme,
+    String? bearerFormat,
+    OpenApiOAuthFlows? flows,
+    String? openIdConnectUrl,
+  }) {
+    return _$OpenApiSecurityScheme._(
+      type: type,
+      description: description,
+      name: name,
+      location: location,
+      scheme: scheme,
+      bearerFormat: bearerFormat,
+      flows: flows,
+      openIdConnectUrl: openIdConnectUrl,
+    );
+  }
+
+  factory OpenApiSecurityScheme.build(
+    void Function(OpenApiSecuritySchemeBuilder) updates,
+  ) = _$OpenApiSecurityScheme;
+
+  OpenApiSecurityScheme._();
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenApiSecuritySchemeBuilder b) {
+    switch (b.type) {
+      case OpenApiSecuritySchemeType.apiKey:
+        if (b.name == null || b.location == null) {
+          throw ArgumentError.value(
+            b,
+            'securityScheme',
+            'name and location are required for apiKey type',
+          );
+        }
+      case OpenApiSecuritySchemeType.http:
+        if (b.scheme == null) {
+          throw ArgumentError.value(
+            b,
+            'securityScheme',
+            'scheme is required for http type',
+          );
+        }
+      case OpenApiSecuritySchemeType.oauth2:
+        if (b._flows == null) {
+          throw ArgumentError.value(
+            b,
+            'securityScheme',
+            'flows is required for oauth2 type',
+          );
+        }
+      case OpenApiSecuritySchemeType.openIdConnect:
+        if (b.openIdConnectUrl == null) {
+          throw ArgumentError.value(
+            b,
+            'securityScheme',
+            'openIdConnectUrl is required for openIdConnect type',
+          );
+        }
+    }
+  }
+
+  /// REQUIRED. The type of the security scheme.
+  OpenApiSecuritySchemeType get type;
+
+  /// A short description for security scheme.
+  ///
+  /// CommonMark syntax MAY be used for rich text representation.
+  @override
+  String? get description;
+
+  /// REQUIRED for apiKey. The name of the header, query or cookie parameter to be used.
+  String? get name;
+
+  /// REQUIRED for apiKey. The location of the API key.
+  OpenApiParameterLocation? get location;
+
+  /// REQUIRED for http. The name of the HTTP Authorization scheme to be used in the Authorization header as defined in RFC7235.
+  ///
+  /// The values used SHOULD be registered in the IANA Authentication Scheme registry.
+  String? get scheme;
+
+  /// A hint to the client to identify how the bearer token is formatted.
+  ///
+  /// Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
+  String? get bearerFormat;
+
+  /// REQUIRED for oauth2. An object containing configuration information for the flow types supported.
+  OpenApiOAuthFlows? get flows;
+
+  /// REQUIRED for openIdConnect. OpenId Connect URL to discover OAuth2 configuration values.
+  ///
+  /// This MUST be in the form of a URL.
+  String? get openIdConnectUrl;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitSecurityScheme(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitSecurityScheme(this, arg);
+}
+
+/// The type of the security scheme.
+final class OpenApiSecuritySchemeType extends EnumClass {
+  const OpenApiSecuritySchemeType._(super.name);
+
+  /// API key in header, query or cookie
+  static const OpenApiSecuritySchemeType apiKey = _$apiKey;
+
+  /// HTTP authentication
+  static const OpenApiSecuritySchemeType http = _$http;
+
+  /// OAuth2 authentication
+  static const OpenApiSecuritySchemeType oauth2 = _$oauth2;
+
+  /// OpenID Connect authentication
+  static const OpenApiSecuritySchemeType openIdConnect = _$openIdConnect;
+
+  static BuiltSet<OpenApiSecuritySchemeType> get values =>
+      _$OpenApiSecuritySchemeTypeValues;
+  static OpenApiSecuritySchemeType valueOf(String name) =>
+      _$OpenApiSecuritySchemeTypeValueOf(name);
+}
+
+/// Allows configuration of the supported OAuth Flows.
+///
+/// https://spec.openapis.org/oas/v3.1.0#oauth-flows-object
+abstract class OpenApiOAuthFlows
+    implements Built<OpenApiOAuthFlows, OpenApiOAuthFlowsBuilder>, OpenApiNode {
+  factory OpenApiOAuthFlows({
+    OpenApiOAuthFlow? implicit,
+    OpenApiOAuthFlow? password,
+    OpenApiOAuthFlow? clientCredentials,
+    OpenApiOAuthFlow? authorizationCode,
+  }) {
+    return _$OpenApiOAuthFlows._(
+      implicit: implicit,
+      password: password,
+      clientCredentials: clientCredentials,
+      authorizationCode: authorizationCode,
+    );
+  }
+
+  factory OpenApiOAuthFlows.build(
+    void Function(OpenApiOAuthFlowsBuilder) updates,
+  ) = _$OpenApiOAuthFlows;
+
+  OpenApiOAuthFlows._();
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenApiOAuthFlowsBuilder b) {
+    if (b._implicit case final implicit?) {
+      if (implicit.authorizationUrl == null) {
+        throw ArgumentError.value(
+          b,
+          'oauthFlows',
+          'authorizationUrl is required for implicit flow',
+        );
+      }
+    }
+    if (b._password case final password?) {
+      if (password.tokenUrl == null) {
+        throw ArgumentError.value(
+          b,
+          'oauthFlows',
+          'tokenUrl is required for password flow',
+        );
+      }
+    }
+    if (b._clientCredentials case final clientCredentials?) {
+      if (clientCredentials.tokenUrl == null) {
+        throw ArgumentError.value(
+          b,
+          'oauthFlows',
+          'tokenUrl is required for clientCredentials flow',
+        );
+      }
+    }
+    if (b._authorizationCode case final authorizationCode?) {
+      if (authorizationCode.authorizationUrl == null ||
+          authorizationCode.tokenUrl == null) {
+        throw ArgumentError.value(
+          b,
+          'oauthFlows',
+          'authorizationUrl and tokenUrl are required for authorizationCode flow',
+        );
+      }
+    }
+  }
+
+  /// Configuration for the OAuth Implicit flow
+  OpenApiOAuthFlow? get implicit;
+
+  /// Configuration for the OAuth Resource Owner Password flow
+  OpenApiOAuthFlow? get password;
+
+  /// Configuration for the OAuth Client Credentials flow
+  OpenApiOAuthFlow? get clientCredentials;
+
+  /// Configuration for the OAuth Authorization Code flow
+  OpenApiOAuthFlow? get authorizationCode;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitOAuthFlows(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitOAuthFlows(this, arg);
+}
+
+/// Configuration details for a supported OAuth Flow
+///
+/// https://spec.openapis.org/oas/v3.1.0#oauth-flow-object
+abstract class OpenApiOAuthFlow
+    implements Built<OpenApiOAuthFlow, OpenApiOAuthFlowBuilder>, OpenApiNode {
+  factory OpenApiOAuthFlow({
+    String? authorizationUrl,
+    String? tokenUrl,
+    String? refreshUrl,
+    Map<String, String> scopes = const {},
+  }) {
+    return _$OpenApiOAuthFlow._(
+      authorizationUrl: authorizationUrl,
+      tokenUrl: tokenUrl,
+      refreshUrl: refreshUrl,
+      scopes: scopes.build(),
+    );
+  }
+
+  factory OpenApiOAuthFlow.build(
+    void Function(OpenApiOAuthFlowBuilder) updates,
+  ) = _$OpenApiOAuthFlow;
+
+  OpenApiOAuthFlow._();
+
+  /// REQUIRED. The authorization URL to be used for this flow.
+  ///
+  /// This MUST be in the form of a URL.
+  String? get authorizationUrl;
+
+  /// REQUIRED. The token URL to be used for this flow.
+  ///
+  /// This MUST be in the form of a URL.
+  String? get tokenUrl;
+
+  /// The URL to be used for obtaining refresh tokens.
+  ///
+  /// This MUST be in the form of a URL.
+  String? get refreshUrl;
+
+  /// REQUIRED. The available scopes for the OAuth2 security scheme.
+  ///
+  /// A map between the scope name and a short description for it.
+  BuiltMap<String, String> get scopes;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitOAuthFlow(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitOAuthFlow(this, arg);
+}
+
+/// Lists the required security schemes to execute this operation.
+///
+/// The name used for each property MUST correspond to a security scheme
+/// declared in the Security Schemes under the Components Object.
+///
+/// Security Requirement Objects that contain multiple schemes require that
+/// all schemes MUST be satisfied for a request to be authorized. This enables
+/// support for scenarios where multiple query parameters or HTTP headers are
+/// required to convey security information.
+///
+/// When a list of Security Requirement Objects is defined on the OpenAPI
+/// Object or Operation Object, only one of the Security Requirement Objects
+/// in the list needs to be satisfied to authorize the request.
+///
+/// https://spec.openapis.org/oas/v3.1.0#security-requirement-object
+abstract class OpenApiSecurityRequirement
+    implements
+        Built<OpenApiSecurityRequirement, OpenApiSecurityRequirementBuilder>,
+        OpenApiNode {
+  factory OpenApiSecurityRequirement({
+    Map<String, List<String>> schemes = const {},
+  }) {
+    return _$OpenApiSecurityRequirement._(
+      schemes: schemes.map((k, v) => MapEntry(k, v.build())).build(),
+    );
+  }
+
+  factory OpenApiSecurityRequirement.build(
+    void Function(OpenApiSecurityRequirementBuilder) updates,
+  ) = _$OpenApiSecurityRequirement;
+
+  OpenApiSecurityRequirement._();
+
+  /// Each name MUST correspond to a security scheme which is declared in the
+  /// Security Schemes under the Components Object. If the security scheme is
+  /// of type "oauth2" or "openIdConnect", then the value is a list of scope
+  /// names required for the execution. For other security scheme types, the
+  /// array MUST be empty.
+  BuiltMap<String, BuiltList<String>> get schemes;
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) =>
+      visitor.visitSecurityRequirement(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) =>
+      visitor.visitSecurityRequirement(this, arg);
+}

--- a/apps/cli/lib/src/openapi/ast/openapi_ast.g.dart
+++ b/apps/cli/lib/src/openapi/ast/openapi_ast.g.dart
@@ -1,0 +1,5326 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'openapi_ast.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+const OpenApiOperationType _$get = const OpenApiOperationType._('get');
+const OpenApiOperationType _$put = const OpenApiOperationType._('put');
+const OpenApiOperationType _$post = const OpenApiOperationType._('post');
+const OpenApiOperationType _$delete = const OpenApiOperationType._('delete');
+const OpenApiOperationType _$options = const OpenApiOperationType._('options');
+const OpenApiOperationType _$head = const OpenApiOperationType._('head');
+const OpenApiOperationType _$patch = const OpenApiOperationType._('patch');
+const OpenApiOperationType _$trace = const OpenApiOperationType._('trace');
+
+OpenApiOperationType _$OpenApiOperationTypeValueOf(String name) {
+  switch (name) {
+    case 'get':
+      return _$get;
+    case 'put':
+      return _$put;
+    case 'post':
+      return _$post;
+    case 'delete':
+      return _$delete;
+    case 'options':
+      return _$options;
+    case 'head':
+      return _$head;
+    case 'patch':
+      return _$patch;
+    case 'trace':
+      return _$trace;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<OpenApiOperationType> _$OpenApiOperationTypeValues =
+    new BuiltSet<OpenApiOperationType>(const <OpenApiOperationType>[
+  _$get,
+  _$put,
+  _$post,
+  _$delete,
+  _$options,
+  _$head,
+  _$patch,
+  _$trace,
+]);
+
+const OpenApiParameterLocation _$query =
+    const OpenApiParameterLocation._('query');
+const OpenApiParameterLocation _$header =
+    const OpenApiParameterLocation._('header');
+const OpenApiParameterLocation _$path =
+    const OpenApiParameterLocation._('path');
+const OpenApiParameterLocation _$cookie =
+    const OpenApiParameterLocation._('cookie');
+
+OpenApiParameterLocation _$OpenApiParameterLocationValueOf(String name) {
+  switch (name) {
+    case 'query':
+      return _$query;
+    case 'header':
+      return _$header;
+    case 'path':
+      return _$path;
+    case 'cookie':
+      return _$cookie;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<OpenApiParameterLocation> _$OpenApiParameterLocationValues =
+    new BuiltSet<OpenApiParameterLocation>(const <OpenApiParameterLocation>[
+  _$query,
+  _$header,
+  _$path,
+  _$cookie,
+]);
+
+const OpenApiParameterStyle _$matrix = const OpenApiParameterStyle._('matrix');
+const OpenApiParameterStyle _$label = const OpenApiParameterStyle._('label');
+const OpenApiParameterStyle _$form = const OpenApiParameterStyle._('form');
+const OpenApiParameterStyle _$simple = const OpenApiParameterStyle._('simple');
+const OpenApiParameterStyle _$spaceDelimited =
+    const OpenApiParameterStyle._('spaceDelimited');
+const OpenApiParameterStyle _$pipeDelimited =
+    const OpenApiParameterStyle._('pipeDelimited');
+const OpenApiParameterStyle _$deepObject =
+    const OpenApiParameterStyle._('deepObject');
+
+OpenApiParameterStyle _$OpenApiParameterStyleValueOf(String name) {
+  switch (name) {
+    case 'matrix':
+      return _$matrix;
+    case 'label':
+      return _$label;
+    case 'form':
+      return _$form;
+    case 'simple':
+      return _$simple;
+    case 'spaceDelimited':
+      return _$spaceDelimited;
+    case 'pipeDelimited':
+      return _$pipeDelimited;
+    case 'deepObject':
+      return _$deepObject;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<OpenApiParameterStyle> _$OpenApiParameterStyleValues =
+    new BuiltSet<OpenApiParameterStyle>(const <OpenApiParameterStyle>[
+  _$matrix,
+  _$label,
+  _$form,
+  _$simple,
+  _$spaceDelimited,
+  _$pipeDelimited,
+  _$deepObject,
+]);
+
+const OpenApiSecuritySchemeType _$apiKey =
+    const OpenApiSecuritySchemeType._('apiKey');
+const OpenApiSecuritySchemeType _$http =
+    const OpenApiSecuritySchemeType._('http');
+const OpenApiSecuritySchemeType _$oauth2 =
+    const OpenApiSecuritySchemeType._('oauth2');
+const OpenApiSecuritySchemeType _$openIdConnect =
+    const OpenApiSecuritySchemeType._('openIdConnect');
+
+OpenApiSecuritySchemeType _$OpenApiSecuritySchemeTypeValueOf(String name) {
+  switch (name) {
+    case 'apiKey':
+      return _$apiKey;
+    case 'http':
+      return _$http;
+    case 'oauth2':
+      return _$oauth2;
+    case 'openIdConnect':
+      return _$openIdConnect;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<OpenApiSecuritySchemeType> _$OpenApiSecuritySchemeTypeValues =
+    new BuiltSet<OpenApiSecuritySchemeType>(const <OpenApiSecuritySchemeType>[
+  _$apiKey,
+  _$http,
+  _$oauth2,
+  _$openIdConnect,
+]);
+
+abstract mixin class OpenApiComponentBuilder<T extends OpenApiComponent<T>> {
+  void replace(OpenApiComponent<T> other);
+  void update(void Function(OpenApiComponentBuilder<T>) updates);
+  String? get summary;
+  set summary(String? summary);
+
+  String? get description;
+  set description(String? description);
+
+  String? get ref;
+  set ref(String? ref);
+
+  YamlNode? get node;
+  set node(YamlNode? node);
+}
+
+class _$OpenApiDocument extends OpenApiDocument {
+  @override
+  final Version version;
+  @override
+  final OpenApiInfo info;
+  @override
+  final String? jsonSchemaDialect;
+  @override
+  final BuiltList<OpenApiServer> servers;
+  @override
+  final BuiltMap<String, OpenApiComponentOrRef<OpenApiPathItem>> paths;
+  @override
+  final OpenApiComponents components;
+  @override
+  final BuiltList<OpenApiSecurityRequirement> securityRequirements;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiDocument([void Function(OpenApiDocumentBuilder)? updates]) =>
+      (new OpenApiDocumentBuilder()..update(updates))._build();
+
+  _$OpenApiDocument._(
+      {required this.version,
+      required this.info,
+      this.jsonSchemaDialect,
+      required this.servers,
+      required this.paths,
+      required this.components,
+      required this.securityRequirements,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        version, r'OpenApiDocument', 'version');
+    BuiltValueNullFieldError.checkNotNull(info, r'OpenApiDocument', 'info');
+    BuiltValueNullFieldError.checkNotNull(
+        servers, r'OpenApiDocument', 'servers');
+    BuiltValueNullFieldError.checkNotNull(paths, r'OpenApiDocument', 'paths');
+    BuiltValueNullFieldError.checkNotNull(
+        components, r'OpenApiDocument', 'components');
+    BuiltValueNullFieldError.checkNotNull(
+        securityRequirements, r'OpenApiDocument', 'securityRequirements');
+  }
+
+  @override
+  OpenApiDocument rebuild(void Function(OpenApiDocumentBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiDocumentBuilder toBuilder() =>
+      new OpenApiDocumentBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiDocument &&
+        version == other.version &&
+        info == other.info &&
+        jsonSchemaDialect == other.jsonSchemaDialect &&
+        servers == other.servers &&
+        paths == other.paths &&
+        components == other.components &&
+        securityRequirements == other.securityRequirements &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, version.hashCode);
+    _$hash = $jc(_$hash, info.hashCode);
+    _$hash = $jc(_$hash, jsonSchemaDialect.hashCode);
+    _$hash = $jc(_$hash, servers.hashCode);
+    _$hash = $jc(_$hash, paths.hashCode);
+    _$hash = $jc(_$hash, components.hashCode);
+    _$hash = $jc(_$hash, securityRequirements.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiDocument')
+          ..add('version', version)
+          ..add('info', info)
+          ..add('jsonSchemaDialect', jsonSchemaDialect)
+          ..add('servers', servers)
+          ..add('paths', paths)
+          ..add('components', components)
+          ..add('securityRequirements', securityRequirements)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiDocumentBuilder
+    implements Builder<OpenApiDocument, OpenApiDocumentBuilder> {
+  _$OpenApiDocument? _$v;
+
+  Version? _version;
+  Version? get version => _$this._version;
+  set version(Version? version) => _$this._version = version;
+
+  OpenApiInfoBuilder? _info;
+  OpenApiInfoBuilder get info => _$this._info ??= new OpenApiInfoBuilder();
+  set info(OpenApiInfoBuilder? info) => _$this._info = info;
+
+  String? _jsonSchemaDialect;
+  String? get jsonSchemaDialect => _$this._jsonSchemaDialect;
+  set jsonSchemaDialect(String? jsonSchemaDialect) =>
+      _$this._jsonSchemaDialect = jsonSchemaDialect;
+
+  ListBuilder<OpenApiServer>? _servers;
+  ListBuilder<OpenApiServer> get servers =>
+      _$this._servers ??= new ListBuilder<OpenApiServer>();
+  set servers(ListBuilder<OpenApiServer>? servers) => _$this._servers = servers;
+
+  MapBuilder<String, OpenApiComponentOrRef<OpenApiPathItem>>? _paths;
+  MapBuilder<String, OpenApiComponentOrRef<OpenApiPathItem>> get paths =>
+      _$this._paths ??=
+          new MapBuilder<String, OpenApiComponentOrRef<OpenApiPathItem>>();
+  set paths(
+          MapBuilder<String, OpenApiComponentOrRef<OpenApiPathItem>>? paths) =>
+      _$this._paths = paths;
+
+  OpenApiComponentsBuilder? _components;
+  OpenApiComponentsBuilder get components =>
+      _$this._components ??= new OpenApiComponentsBuilder();
+  set components(OpenApiComponentsBuilder? components) =>
+      _$this._components = components;
+
+  ListBuilder<OpenApiSecurityRequirement>? _securityRequirements;
+  ListBuilder<OpenApiSecurityRequirement> get securityRequirements =>
+      _$this._securityRequirements ??=
+          new ListBuilder<OpenApiSecurityRequirement>();
+  set securityRequirements(
+          ListBuilder<OpenApiSecurityRequirement>? securityRequirements) =>
+      _$this._securityRequirements = securityRequirements;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiDocumentBuilder();
+
+  OpenApiDocumentBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _version = $v.version;
+      _info = $v.info.toBuilder();
+      _jsonSchemaDialect = $v.jsonSchemaDialect;
+      _servers = $v.servers.toBuilder();
+      _paths = $v.paths.toBuilder();
+      _components = $v.components.toBuilder();
+      _securityRequirements = $v.securityRequirements.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiDocument other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiDocument;
+  }
+
+  @override
+  void update(void Function(OpenApiDocumentBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiDocument build() => _build();
+
+  _$OpenApiDocument _build() {
+    _$OpenApiDocument _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiDocument._(
+            version: BuiltValueNullFieldError.checkNotNull(
+                version, r'OpenApiDocument', 'version'),
+            info: info.build(),
+            jsonSchemaDialect: jsonSchemaDialect,
+            servers: servers.build(),
+            paths: paths.build(),
+            components: components.build(),
+            securityRequirements: securityRequirements.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'info';
+        info.build();
+
+        _$failedField = 'servers';
+        servers.build();
+        _$failedField = 'paths';
+        paths.build();
+        _$failedField = 'components';
+        components.build();
+        _$failedField = 'securityRequirements';
+        securityRequirements.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiDocument', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiInfo extends OpenApiInfo {
+  @override
+  final String? title;
+  @override
+  final String? description;
+  @override
+  final String? apiVersion;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiInfo([void Function(OpenApiInfoBuilder)? updates]) =>
+      (new OpenApiInfoBuilder()..update(updates))._build();
+
+  _$OpenApiInfo._(
+      {this.title, this.description, this.apiVersion, this.ref, this.node})
+      : super._();
+
+  @override
+  OpenApiInfo rebuild(void Function(OpenApiInfoBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiInfoBuilder toBuilder() => new OpenApiInfoBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiInfo &&
+        title == other.title &&
+        description == other.description &&
+        apiVersion == other.apiVersion &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, apiVersion.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiInfo')
+          ..add('title', title)
+          ..add('description', description)
+          ..add('apiVersion', apiVersion)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiInfoBuilder implements Builder<OpenApiInfo, OpenApiInfoBuilder> {
+  _$OpenApiInfo? _$v;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  String? _apiVersion;
+  String? get apiVersion => _$this._apiVersion;
+  set apiVersion(String? apiVersion) => _$this._apiVersion = apiVersion;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiInfoBuilder();
+
+  OpenApiInfoBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _title = $v.title;
+      _description = $v.description;
+      _apiVersion = $v.apiVersion;
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiInfo other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiInfo;
+  }
+
+  @override
+  void update(void Function(OpenApiInfoBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiInfo build() => _build();
+
+  _$OpenApiInfo _build() {
+    final _$result = _$v ??
+        new _$OpenApiInfo._(
+          title: title,
+          description: description,
+          apiVersion: apiVersion,
+          ref: ref,
+          node: node,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiServer extends OpenApiServer {
+  @override
+  final String url;
+  @override
+  final String? description;
+  @override
+  final BuiltMap<String, OpenApiServerVariable> variables;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiServer([void Function(OpenApiServerBuilder)? updates]) =>
+      (new OpenApiServerBuilder()..update(updates))._build();
+
+  _$OpenApiServer._(
+      {required this.url,
+      this.description,
+      required this.variables,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(url, r'OpenApiServer', 'url');
+    BuiltValueNullFieldError.checkNotNull(
+        variables, r'OpenApiServer', 'variables');
+  }
+
+  @override
+  OpenApiServer rebuild(void Function(OpenApiServerBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiServerBuilder toBuilder() => new OpenApiServerBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiServer &&
+        url == other.url &&
+        description == other.description &&
+        variables == other.variables &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, url.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, variables.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiServer')
+          ..add('url', url)
+          ..add('description', description)
+          ..add('variables', variables)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiServerBuilder
+    implements Builder<OpenApiServer, OpenApiServerBuilder> {
+  _$OpenApiServer? _$v;
+
+  String? _url;
+  String? get url => _$this._url;
+  set url(String? url) => _$this._url = url;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  MapBuilder<String, OpenApiServerVariable>? _variables;
+  MapBuilder<String, OpenApiServerVariable> get variables =>
+      _$this._variables ??= new MapBuilder<String, OpenApiServerVariable>();
+  set variables(MapBuilder<String, OpenApiServerVariable>? variables) =>
+      _$this._variables = variables;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiServerBuilder();
+
+  OpenApiServerBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _url = $v.url;
+      _description = $v.description;
+      _variables = $v.variables.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiServer other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiServer;
+  }
+
+  @override
+  void update(void Function(OpenApiServerBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiServer build() => _build();
+
+  _$OpenApiServer _build() {
+    _$OpenApiServer _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiServer._(
+            url: BuiltValueNullFieldError.checkNotNull(
+                url, r'OpenApiServer', 'url'),
+            description: description,
+            variables: variables.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'variables';
+        variables.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiServer', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiServerVariable extends OpenApiServerVariable {
+  @override
+  final String name;
+  @override
+  final BuiltList<String>? enumValues;
+  @override
+  final String defaultValue;
+  @override
+  final String? description;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiServerVariable(
+          [void Function(OpenApiServerVariableBuilder)? updates]) =>
+      (new OpenApiServerVariableBuilder()..update(updates))._build();
+
+  _$OpenApiServerVariable._(
+      {required this.name,
+      this.enumValues,
+      required this.defaultValue,
+      this.description,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        name, r'OpenApiServerVariable', 'name');
+    BuiltValueNullFieldError.checkNotNull(
+        defaultValue, r'OpenApiServerVariable', 'defaultValue');
+  }
+
+  @override
+  OpenApiServerVariable rebuild(
+          void Function(OpenApiServerVariableBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiServerVariableBuilder toBuilder() =>
+      new OpenApiServerVariableBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiServerVariable &&
+        name == other.name &&
+        enumValues == other.enumValues &&
+        defaultValue == other.defaultValue &&
+        description == other.description &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, enumValues.hashCode);
+    _$hash = $jc(_$hash, defaultValue.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiServerVariable')
+          ..add('name', name)
+          ..add('enumValues', enumValues)
+          ..add('defaultValue', defaultValue)
+          ..add('description', description)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiServerVariableBuilder
+    implements Builder<OpenApiServerVariable, OpenApiServerVariableBuilder> {
+  _$OpenApiServerVariable? _$v;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  ListBuilder<String>? _enumValues;
+  ListBuilder<String> get enumValues =>
+      _$this._enumValues ??= new ListBuilder<String>();
+  set enumValues(ListBuilder<String>? enumValues) =>
+      _$this._enumValues = enumValues;
+
+  String? _defaultValue;
+  String? get defaultValue => _$this._defaultValue;
+  set defaultValue(String? defaultValue) => _$this._defaultValue = defaultValue;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiServerVariableBuilder();
+
+  OpenApiServerVariableBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _name = $v.name;
+      _enumValues = $v.enumValues?.toBuilder();
+      _defaultValue = $v.defaultValue;
+      _description = $v.description;
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiServerVariable other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiServerVariable;
+  }
+
+  @override
+  void update(void Function(OpenApiServerVariableBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiServerVariable build() => _build();
+
+  _$OpenApiServerVariable _build() {
+    _$OpenApiServerVariable _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiServerVariable._(
+            name: BuiltValueNullFieldError.checkNotNull(
+                name, r'OpenApiServerVariable', 'name'),
+            enumValues: _enumValues?.build(),
+            defaultValue: BuiltValueNullFieldError.checkNotNull(
+                defaultValue, r'OpenApiServerVariable', 'defaultValue'),
+            description: description,
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'enumValues';
+        _enumValues?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiServerVariable', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiPathItem extends OpenApiPathItem {
+  @override
+  final String? summary;
+  @override
+  final String? description;
+  @override
+  final BuiltMap<OpenApiOperationType, OpenApiOperation> operations;
+  @override
+  final BuiltList<OpenApiServer>? servers;
+  @override
+  final BuiltList<OpenApiComponentOrRef<OpenApiParameter>> parameters;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiPathItem([void Function(OpenApiPathItemBuilder)? updates]) =>
+      (new OpenApiPathItemBuilder()..update(updates))._build();
+
+  _$OpenApiPathItem._(
+      {this.summary,
+      this.description,
+      required this.operations,
+      this.servers,
+      required this.parameters,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        operations, r'OpenApiPathItem', 'operations');
+    BuiltValueNullFieldError.checkNotNull(
+        parameters, r'OpenApiPathItem', 'parameters');
+  }
+
+  @override
+  OpenApiPathItem rebuild(void Function(OpenApiPathItemBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiPathItemBuilder toBuilder() =>
+      new OpenApiPathItemBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiPathItem &&
+        summary == other.summary &&
+        description == other.description &&
+        operations == other.operations &&
+        servers == other.servers &&
+        parameters == other.parameters &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, operations.hashCode);
+    _$hash = $jc(_$hash, servers.hashCode);
+    _$hash = $jc(_$hash, parameters.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiPathItem')
+          ..add('summary', summary)
+          ..add('description', description)
+          ..add('operations', operations)
+          ..add('servers', servers)
+          ..add('parameters', parameters)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiPathItemBuilder
+    implements
+        Builder<OpenApiPathItem, OpenApiPathItemBuilder>,
+        OpenApiComponentBuilder<OpenApiPathItem> {
+  _$OpenApiPathItem? _$v;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(covariant String? summary) => _$this._summary = summary;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(covariant String? description) =>
+      _$this._description = description;
+
+  MapBuilder<OpenApiOperationType, OpenApiOperation>? _operations;
+  MapBuilder<OpenApiOperationType, OpenApiOperation> get operations =>
+      _$this._operations ??=
+          new MapBuilder<OpenApiOperationType, OpenApiOperation>();
+  set operations(
+          covariant MapBuilder<OpenApiOperationType, OpenApiOperation>?
+              operations) =>
+      _$this._operations = operations;
+
+  ListBuilder<OpenApiServer>? _servers;
+  ListBuilder<OpenApiServer> get servers =>
+      _$this._servers ??= new ListBuilder<OpenApiServer>();
+  set servers(covariant ListBuilder<OpenApiServer>? servers) =>
+      _$this._servers = servers;
+
+  ListBuilder<OpenApiComponentOrRef<OpenApiParameter>>? _parameters;
+  ListBuilder<OpenApiComponentOrRef<OpenApiParameter>> get parameters =>
+      _$this._parameters ??=
+          new ListBuilder<OpenApiComponentOrRef<OpenApiParameter>>();
+  set parameters(
+          covariant ListBuilder<OpenApiComponentOrRef<OpenApiParameter>>?
+              parameters) =>
+      _$this._parameters = parameters;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(covariant String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(covariant YamlNode? node) => _$this._node = node;
+
+  OpenApiPathItemBuilder();
+
+  OpenApiPathItemBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _summary = $v.summary;
+      _description = $v.description;
+      _operations = $v.operations.toBuilder();
+      _servers = $v.servers?.toBuilder();
+      _parameters = $v.parameters.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OpenApiPathItem other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiPathItem;
+  }
+
+  @override
+  void update(void Function(OpenApiPathItemBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiPathItem build() => _build();
+
+  _$OpenApiPathItem _build() {
+    _$OpenApiPathItem _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiPathItem._(
+            summary: summary,
+            description: description,
+            operations: operations.build(),
+            servers: _servers?.build(),
+            parameters: parameters.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'operations';
+        operations.build();
+        _$failedField = 'servers';
+        _servers?.build();
+        _$failedField = 'parameters';
+        parameters.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiPathItem', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiOperation extends OpenApiOperation {
+  @override
+  final OpenApiOperationType type;
+  @override
+  final BuiltList<String> tags;
+  @override
+  final String? summary;
+  @override
+  final String? description;
+  @override
+  final String? operationId;
+  @override
+  final BuiltList<OpenApiComponentOrRef<OpenApiParameter>> parameters;
+  @override
+  final OpenApiComponentOrRef<OpenApiRequestBody>? requestBody;
+  @override
+  final BuiltMap<StatusCodeOrRange, OpenApiComponentOrRef<OpenApiResponse>>
+      responses;
+  @override
+  final OpenApiComponentOrRef<OpenApiResponse>? defaultResponse;
+  @override
+  final bool deprecated;
+  @override
+  final BuiltList<OpenApiServer>? servers;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiOperation(
+          [void Function(OpenApiOperationBuilder)? updates]) =>
+      (new OpenApiOperationBuilder()..update(updates))._build();
+
+  _$OpenApiOperation._(
+      {required this.type,
+      required this.tags,
+      this.summary,
+      this.description,
+      this.operationId,
+      required this.parameters,
+      this.requestBody,
+      required this.responses,
+      this.defaultResponse,
+      required this.deprecated,
+      this.servers,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(type, r'OpenApiOperation', 'type');
+    BuiltValueNullFieldError.checkNotNull(tags, r'OpenApiOperation', 'tags');
+    BuiltValueNullFieldError.checkNotNull(
+        parameters, r'OpenApiOperation', 'parameters');
+    BuiltValueNullFieldError.checkNotNull(
+        responses, r'OpenApiOperation', 'responses');
+    BuiltValueNullFieldError.checkNotNull(
+        deprecated, r'OpenApiOperation', 'deprecated');
+  }
+
+  @override
+  OpenApiOperation rebuild(void Function(OpenApiOperationBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiOperationBuilder toBuilder() =>
+      new OpenApiOperationBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiOperation &&
+        type == other.type &&
+        tags == other.tags &&
+        summary == other.summary &&
+        description == other.description &&
+        operationId == other.operationId &&
+        parameters == other.parameters &&
+        requestBody == other.requestBody &&
+        responses == other.responses &&
+        defaultResponse == other.defaultResponse &&
+        deprecated == other.deprecated &&
+        servers == other.servers &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, type.hashCode);
+    _$hash = $jc(_$hash, tags.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, operationId.hashCode);
+    _$hash = $jc(_$hash, parameters.hashCode);
+    _$hash = $jc(_$hash, requestBody.hashCode);
+    _$hash = $jc(_$hash, responses.hashCode);
+    _$hash = $jc(_$hash, defaultResponse.hashCode);
+    _$hash = $jc(_$hash, deprecated.hashCode);
+    _$hash = $jc(_$hash, servers.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiOperation')
+          ..add('type', type)
+          ..add('tags', tags)
+          ..add('summary', summary)
+          ..add('description', description)
+          ..add('operationId', operationId)
+          ..add('parameters', parameters)
+          ..add('requestBody', requestBody)
+          ..add('responses', responses)
+          ..add('defaultResponse', defaultResponse)
+          ..add('deprecated', deprecated)
+          ..add('servers', servers)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiOperationBuilder
+    implements Builder<OpenApiOperation, OpenApiOperationBuilder> {
+  _$OpenApiOperation? _$v;
+
+  OpenApiOperationType? _type;
+  OpenApiOperationType? get type => _$this._type;
+  set type(OpenApiOperationType? type) => _$this._type = type;
+
+  ListBuilder<String>? _tags;
+  ListBuilder<String> get tags => _$this._tags ??= new ListBuilder<String>();
+  set tags(ListBuilder<String>? tags) => _$this._tags = tags;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(String? summary) => _$this._summary = summary;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  String? _operationId;
+  String? get operationId => _$this._operationId;
+  set operationId(String? operationId) => _$this._operationId = operationId;
+
+  ListBuilder<OpenApiComponentOrRef<OpenApiParameter>>? _parameters;
+  ListBuilder<OpenApiComponentOrRef<OpenApiParameter>> get parameters =>
+      _$this._parameters ??=
+          new ListBuilder<OpenApiComponentOrRef<OpenApiParameter>>();
+  set parameters(
+          ListBuilder<OpenApiComponentOrRef<OpenApiParameter>>? parameters) =>
+      _$this._parameters = parameters;
+
+  OpenApiComponentOrRefBuilder<OpenApiRequestBody>? _requestBody;
+  OpenApiComponentOrRefBuilder<OpenApiRequestBody> get requestBody =>
+      _$this._requestBody ??=
+          new OpenApiComponentOrRefBuilder<OpenApiRequestBody>();
+  set requestBody(
+          OpenApiComponentOrRefBuilder<OpenApiRequestBody>? requestBody) =>
+      _$this._requestBody = requestBody;
+
+  MapBuilder<StatusCodeOrRange, OpenApiComponentOrRef<OpenApiResponse>>?
+      _responses;
+  MapBuilder<StatusCodeOrRange, OpenApiComponentOrRef<OpenApiResponse>>
+      get responses => _$this._responses ??= new MapBuilder<StatusCodeOrRange,
+          OpenApiComponentOrRef<OpenApiResponse>>();
+  set responses(
+          MapBuilder<StatusCodeOrRange, OpenApiComponentOrRef<OpenApiResponse>>?
+              responses) =>
+      _$this._responses = responses;
+
+  OpenApiComponentOrRefBuilder<OpenApiResponse>? _defaultResponse;
+  OpenApiComponentOrRefBuilder<OpenApiResponse> get defaultResponse =>
+      _$this._defaultResponse ??=
+          new OpenApiComponentOrRefBuilder<OpenApiResponse>();
+  set defaultResponse(
+          OpenApiComponentOrRefBuilder<OpenApiResponse>? defaultResponse) =>
+      _$this._defaultResponse = defaultResponse;
+
+  bool? _deprecated;
+  bool? get deprecated => _$this._deprecated;
+  set deprecated(bool? deprecated) => _$this._deprecated = deprecated;
+
+  ListBuilder<OpenApiServer>? _servers;
+  ListBuilder<OpenApiServer> get servers =>
+      _$this._servers ??= new ListBuilder<OpenApiServer>();
+  set servers(ListBuilder<OpenApiServer>? servers) => _$this._servers = servers;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiOperationBuilder();
+
+  OpenApiOperationBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _type = $v.type;
+      _tags = $v.tags.toBuilder();
+      _summary = $v.summary;
+      _description = $v.description;
+      _operationId = $v.operationId;
+      _parameters = $v.parameters.toBuilder();
+      _requestBody = $v.requestBody?.toBuilder();
+      _responses = $v.responses.toBuilder();
+      _defaultResponse = $v.defaultResponse?.toBuilder();
+      _deprecated = $v.deprecated;
+      _servers = $v.servers?.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiOperation other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiOperation;
+  }
+
+  @override
+  void update(void Function(OpenApiOperationBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiOperation build() => _build();
+
+  _$OpenApiOperation _build() {
+    OpenApiOperation._validate(this);
+    _$OpenApiOperation _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiOperation._(
+            type: BuiltValueNullFieldError.checkNotNull(
+                type, r'OpenApiOperation', 'type'),
+            tags: tags.build(),
+            summary: summary,
+            description: description,
+            operationId: operationId,
+            parameters: parameters.build(),
+            requestBody: _requestBody?.build(),
+            responses: responses.build(),
+            defaultResponse: _defaultResponse?.build(),
+            deprecated: BuiltValueNullFieldError.checkNotNull(
+                deprecated, r'OpenApiOperation', 'deprecated'),
+            servers: _servers?.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'tags';
+        tags.build();
+
+        _$failedField = 'parameters';
+        parameters.build();
+        _$failedField = 'requestBody';
+        _requestBody?.build();
+        _$failedField = 'responses';
+        responses.build();
+        _$failedField = 'defaultResponse';
+        _defaultResponse?.build();
+
+        _$failedField = 'servers';
+        _servers?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiOperation', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiParameter extends OpenApiParameter {
+  @override
+  final String name;
+  @override
+  final OpenApiParameterLocation location;
+  @override
+  final String? description;
+  @override
+  final bool required;
+  @override
+  final bool deprecated;
+  @override
+  final bool allowEmptyValue;
+  @override
+  final OpenApiParameterStyle? style;
+  @override
+  final bool? explode;
+  @override
+  final bool? allowReserved;
+  @override
+  final OpenApiComponentOrRef<OpenApiSchema>? schema;
+  @override
+  final (MediaType, OpenApiMediaType)? content;
+  @override
+  final String? summary;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiParameter(
+          [void Function(OpenApiParameterBuilder)? updates]) =>
+      (new OpenApiParameterBuilder()..update(updates))._build();
+
+  _$OpenApiParameter._(
+      {required this.name,
+      required this.location,
+      this.description,
+      required this.required,
+      required this.deprecated,
+      required this.allowEmptyValue,
+      this.style,
+      this.explode,
+      this.allowReserved,
+      this.schema,
+      this.content,
+      this.summary,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(name, r'OpenApiParameter', 'name');
+    BuiltValueNullFieldError.checkNotNull(
+        location, r'OpenApiParameter', 'location');
+    BuiltValueNullFieldError.checkNotNull(
+        required, r'OpenApiParameter', 'required');
+    BuiltValueNullFieldError.checkNotNull(
+        deprecated, r'OpenApiParameter', 'deprecated');
+    BuiltValueNullFieldError.checkNotNull(
+        allowEmptyValue, r'OpenApiParameter', 'allowEmptyValue');
+  }
+
+  @override
+  OpenApiParameter rebuild(void Function(OpenApiParameterBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiParameterBuilder toBuilder() =>
+      new OpenApiParameterBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    final dynamic _$dynamicOther = other;
+    return other is OpenApiParameter &&
+        name == other.name &&
+        location == other.location &&
+        description == other.description &&
+        required == other.required &&
+        deprecated == other.deprecated &&
+        allowEmptyValue == other.allowEmptyValue &&
+        style == other.style &&
+        explode == other.explode &&
+        allowReserved == other.allowReserved &&
+        schema == other.schema &&
+        content == _$dynamicOther.content &&
+        summary == other.summary &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, location.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, required.hashCode);
+    _$hash = $jc(_$hash, deprecated.hashCode);
+    _$hash = $jc(_$hash, allowEmptyValue.hashCode);
+    _$hash = $jc(_$hash, style.hashCode);
+    _$hash = $jc(_$hash, explode.hashCode);
+    _$hash = $jc(_$hash, allowReserved.hashCode);
+    _$hash = $jc(_$hash, schema.hashCode);
+    _$hash = $jc(_$hash, content.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiParameter')
+          ..add('name', name)
+          ..add('location', location)
+          ..add('description', description)
+          ..add('required', required)
+          ..add('deprecated', deprecated)
+          ..add('allowEmptyValue', allowEmptyValue)
+          ..add('style', style)
+          ..add('explode', explode)
+          ..add('allowReserved', allowReserved)
+          ..add('schema', schema)
+          ..add('content', content)
+          ..add('summary', summary)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiParameterBuilder
+    implements
+        Builder<OpenApiParameter, OpenApiParameterBuilder>,
+        OpenApiComponentBuilder<OpenApiParameter> {
+  _$OpenApiParameter? _$v;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  OpenApiParameterLocation? _location;
+  OpenApiParameterLocation? get location => _$this._location;
+  set location(covariant OpenApiParameterLocation? location) =>
+      _$this._location = location;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(covariant String? description) =>
+      _$this._description = description;
+
+  bool? _required;
+  bool? get required => _$this._required;
+  set required(covariant bool? required) => _$this._required = required;
+
+  bool? _deprecated;
+  bool? get deprecated => _$this._deprecated;
+  set deprecated(covariant bool? deprecated) => _$this._deprecated = deprecated;
+
+  bool? _allowEmptyValue;
+  bool? get allowEmptyValue => _$this._allowEmptyValue;
+  set allowEmptyValue(covariant bool? allowEmptyValue) =>
+      _$this._allowEmptyValue = allowEmptyValue;
+
+  OpenApiParameterStyle? _style;
+  OpenApiParameterStyle? get style => _$this._style;
+  set style(covariant OpenApiParameterStyle? style) => _$this._style = style;
+
+  bool? _explode;
+  bool? get explode => _$this._explode;
+  set explode(covariant bool? explode) => _$this._explode = explode;
+
+  bool? _allowReserved;
+  bool? get allowReserved => _$this._allowReserved;
+  set allowReserved(covariant bool? allowReserved) =>
+      _$this._allowReserved = allowReserved;
+
+  OpenApiComponentOrRefBuilder<OpenApiSchema>? _schema;
+  OpenApiComponentOrRefBuilder<OpenApiSchema> get schema =>
+      _$this._schema ??= new OpenApiComponentOrRefBuilder<OpenApiSchema>();
+  set schema(covariant OpenApiComponentOrRefBuilder<OpenApiSchema>? schema) =>
+      _$this._schema = schema;
+
+  (MediaType, OpenApiMediaType)? _content;
+  (MediaType, OpenApiMediaType)? get content => _$this._content;
+  set content(covariant (MediaType, OpenApiMediaType)? content) =>
+      _$this._content = content;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(covariant String? summary) => _$this._summary = summary;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(covariant String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(covariant YamlNode? node) => _$this._node = node;
+
+  OpenApiParameterBuilder();
+
+  OpenApiParameterBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _name = $v.name;
+      _location = $v.location;
+      _description = $v.description;
+      _required = $v.required;
+      _deprecated = $v.deprecated;
+      _allowEmptyValue = $v.allowEmptyValue;
+      _style = $v.style;
+      _explode = $v.explode;
+      _allowReserved = $v.allowReserved;
+      _schema = $v.schema?.toBuilder();
+      _content = $v.content;
+      _summary = $v.summary;
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OpenApiParameter other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiParameter;
+  }
+
+  @override
+  void update(void Function(OpenApiParameterBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiParameter build() => _build();
+
+  _$OpenApiParameter _build() {
+    OpenApiParameter._validate(this);
+    _$OpenApiParameter _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiParameter._(
+            name: BuiltValueNullFieldError.checkNotNull(
+                name, r'OpenApiParameter', 'name'),
+            location: BuiltValueNullFieldError.checkNotNull(
+                location, r'OpenApiParameter', 'location'),
+            description: description,
+            required: BuiltValueNullFieldError.checkNotNull(
+                required, r'OpenApiParameter', 'required'),
+            deprecated: BuiltValueNullFieldError.checkNotNull(
+                deprecated, r'OpenApiParameter', 'deprecated'),
+            allowEmptyValue: BuiltValueNullFieldError.checkNotNull(
+                allowEmptyValue, r'OpenApiParameter', 'allowEmptyValue'),
+            style: style,
+            explode: explode,
+            allowReserved: allowReserved,
+            schema: _schema?.build(),
+            content: content,
+            summary: summary,
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'schema';
+        _schema?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiParameter', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiMediaType extends OpenApiMediaType {
+  @override
+  final OpenApiComponentOrRef<OpenApiSchema> schema;
+  @override
+  final BuiltMap<String, OpenApiEncoding> encoding;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiMediaType(
+          [void Function(OpenApiMediaTypeBuilder)? updates]) =>
+      (new OpenApiMediaTypeBuilder()..update(updates))._build();
+
+  _$OpenApiMediaType._(
+      {required this.schema, required this.encoding, this.ref, this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        schema, r'OpenApiMediaType', 'schema');
+    BuiltValueNullFieldError.checkNotNull(
+        encoding, r'OpenApiMediaType', 'encoding');
+  }
+
+  @override
+  OpenApiMediaType rebuild(void Function(OpenApiMediaTypeBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiMediaTypeBuilder toBuilder() =>
+      new OpenApiMediaTypeBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiMediaType &&
+        schema == other.schema &&
+        encoding == other.encoding &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, schema.hashCode);
+    _$hash = $jc(_$hash, encoding.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiMediaType')
+          ..add('schema', schema)
+          ..add('encoding', encoding)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiMediaTypeBuilder
+    implements Builder<OpenApiMediaType, OpenApiMediaTypeBuilder> {
+  _$OpenApiMediaType? _$v;
+
+  OpenApiComponentOrRefBuilder<OpenApiSchema>? _schema;
+  OpenApiComponentOrRefBuilder<OpenApiSchema> get schema =>
+      _$this._schema ??= new OpenApiComponentOrRefBuilder<OpenApiSchema>();
+  set schema(OpenApiComponentOrRefBuilder<OpenApiSchema>? schema) =>
+      _$this._schema = schema;
+
+  MapBuilder<String, OpenApiEncoding>? _encoding;
+  MapBuilder<String, OpenApiEncoding> get encoding =>
+      _$this._encoding ??= new MapBuilder<String, OpenApiEncoding>();
+  set encoding(MapBuilder<String, OpenApiEncoding>? encoding) =>
+      _$this._encoding = encoding;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiMediaTypeBuilder();
+
+  OpenApiMediaTypeBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _schema = $v.schema.toBuilder();
+      _encoding = $v.encoding.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiMediaType other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiMediaType;
+  }
+
+  @override
+  void update(void Function(OpenApiMediaTypeBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiMediaType build() => _build();
+
+  _$OpenApiMediaType _build() {
+    _$OpenApiMediaType _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiMediaType._(
+            schema: schema.build(),
+            encoding: encoding.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'schema';
+        schema.build();
+        _$failedField = 'encoding';
+        encoding.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiMediaType', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiRequestBody extends OpenApiRequestBody {
+  @override
+  final BuiltMap<MediaType, OpenApiMediaType> content;
+  @override
+  final String? description;
+  @override
+  final bool required;
+  @override
+  final String? summary;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiRequestBody(
+          [void Function(OpenApiRequestBodyBuilder)? updates]) =>
+      (new OpenApiRequestBodyBuilder()..update(updates))._build();
+
+  _$OpenApiRequestBody._(
+      {required this.content,
+      this.description,
+      required this.required,
+      this.summary,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        content, r'OpenApiRequestBody', 'content');
+    BuiltValueNullFieldError.checkNotNull(
+        required, r'OpenApiRequestBody', 'required');
+  }
+
+  @override
+  OpenApiRequestBody rebuild(
+          void Function(OpenApiRequestBodyBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiRequestBodyBuilder toBuilder() =>
+      new OpenApiRequestBodyBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiRequestBody &&
+        content == other.content &&
+        description == other.description &&
+        required == other.required &&
+        summary == other.summary &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, content.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, required.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiRequestBody')
+          ..add('content', content)
+          ..add('description', description)
+          ..add('required', required)
+          ..add('summary', summary)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiRequestBodyBuilder
+    implements
+        Builder<OpenApiRequestBody, OpenApiRequestBodyBuilder>,
+        OpenApiComponentBuilder<OpenApiRequestBody> {
+  _$OpenApiRequestBody? _$v;
+
+  MapBuilder<MediaType, OpenApiMediaType>? _content;
+  MapBuilder<MediaType, OpenApiMediaType> get content =>
+      _$this._content ??= new MapBuilder<MediaType, OpenApiMediaType>();
+  set content(covariant MapBuilder<MediaType, OpenApiMediaType>? content) =>
+      _$this._content = content;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(covariant String? description) =>
+      _$this._description = description;
+
+  bool? _required;
+  bool? get required => _$this._required;
+  set required(covariant bool? required) => _$this._required = required;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(covariant String? summary) => _$this._summary = summary;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(covariant String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(covariant YamlNode? node) => _$this._node = node;
+
+  OpenApiRequestBodyBuilder();
+
+  OpenApiRequestBodyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _content = $v.content.toBuilder();
+      _description = $v.description;
+      _required = $v.required;
+      _summary = $v.summary;
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OpenApiRequestBody other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiRequestBody;
+  }
+
+  @override
+  void update(void Function(OpenApiRequestBodyBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiRequestBody build() => _build();
+
+  _$OpenApiRequestBody _build() {
+    OpenApiRequestBody._validate(this);
+    _$OpenApiRequestBody _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiRequestBody._(
+            content: content.build(),
+            description: description,
+            required: BuiltValueNullFieldError.checkNotNull(
+                required, r'OpenApiRequestBody', 'required'),
+            summary: summary,
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'content';
+        content.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiRequestBody', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiEncoding extends OpenApiEncoding {
+  @override
+  final MediaType contentType;
+  @override
+  final BuiltMap<String, OpenApiComponentOrRef<OpenApiHeader>> headers;
+  @override
+  final OpenApiParameterStyle? style;
+  @override
+  final bool explode;
+  @override
+  final bool allowReserved;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiEncoding([void Function(OpenApiEncodingBuilder)? updates]) =>
+      (new OpenApiEncodingBuilder()..update(updates))._build();
+
+  _$OpenApiEncoding._(
+      {required this.contentType,
+      required this.headers,
+      this.style,
+      required this.explode,
+      required this.allowReserved,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        contentType, r'OpenApiEncoding', 'contentType');
+    BuiltValueNullFieldError.checkNotNull(
+        headers, r'OpenApiEncoding', 'headers');
+    BuiltValueNullFieldError.checkNotNull(
+        explode, r'OpenApiEncoding', 'explode');
+    BuiltValueNullFieldError.checkNotNull(
+        allowReserved, r'OpenApiEncoding', 'allowReserved');
+  }
+
+  @override
+  OpenApiEncoding rebuild(void Function(OpenApiEncodingBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiEncodingBuilder toBuilder() =>
+      new OpenApiEncodingBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiEncoding &&
+        contentType == other.contentType &&
+        headers == other.headers &&
+        style == other.style &&
+        explode == other.explode &&
+        allowReserved == other.allowReserved &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, contentType.hashCode);
+    _$hash = $jc(_$hash, headers.hashCode);
+    _$hash = $jc(_$hash, style.hashCode);
+    _$hash = $jc(_$hash, explode.hashCode);
+    _$hash = $jc(_$hash, allowReserved.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiEncoding')
+          ..add('contentType', contentType)
+          ..add('headers', headers)
+          ..add('style', style)
+          ..add('explode', explode)
+          ..add('allowReserved', allowReserved)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiEncodingBuilder
+    implements Builder<OpenApiEncoding, OpenApiEncodingBuilder> {
+  _$OpenApiEncoding? _$v;
+
+  MediaType? _contentType;
+  MediaType? get contentType => _$this._contentType;
+  set contentType(MediaType? contentType) => _$this._contentType = contentType;
+
+  MapBuilder<String, OpenApiComponentOrRef<OpenApiHeader>>? _headers;
+  MapBuilder<String, OpenApiComponentOrRef<OpenApiHeader>> get headers =>
+      _$this._headers ??=
+          new MapBuilder<String, OpenApiComponentOrRef<OpenApiHeader>>();
+  set headers(
+          MapBuilder<String, OpenApiComponentOrRef<OpenApiHeader>>? headers) =>
+      _$this._headers = headers;
+
+  OpenApiParameterStyle? _style;
+  OpenApiParameterStyle? get style => _$this._style;
+  set style(OpenApiParameterStyle? style) => _$this._style = style;
+
+  bool? _explode;
+  bool? get explode => _$this._explode;
+  set explode(bool? explode) => _$this._explode = explode;
+
+  bool? _allowReserved;
+  bool? get allowReserved => _$this._allowReserved;
+  set allowReserved(bool? allowReserved) =>
+      _$this._allowReserved = allowReserved;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiEncodingBuilder();
+
+  OpenApiEncodingBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _contentType = $v.contentType;
+      _headers = $v.headers.toBuilder();
+      _style = $v.style;
+      _explode = $v.explode;
+      _allowReserved = $v.allowReserved;
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiEncoding other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiEncoding;
+  }
+
+  @override
+  void update(void Function(OpenApiEncodingBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiEncoding build() => _build();
+
+  _$OpenApiEncoding _build() {
+    OpenApiEncoding._validate(this);
+    _$OpenApiEncoding _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiEncoding._(
+            contentType: BuiltValueNullFieldError.checkNotNull(
+                contentType, r'OpenApiEncoding', 'contentType'),
+            headers: headers.build(),
+            style: style,
+            explode: BuiltValueNullFieldError.checkNotNull(
+                explode, r'OpenApiEncoding', 'explode'),
+            allowReserved: BuiltValueNullFieldError.checkNotNull(
+                allowReserved, r'OpenApiEncoding', 'allowReserved'),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'headers';
+        headers.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiEncoding', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiResponse extends OpenApiResponse {
+  @override
+  final StatusCodeOrRange? statusCode;
+  @override
+  final String description;
+  @override
+  final BuiltMap<String, OpenApiComponentOrRef<OpenApiHeader>> headers;
+  @override
+  final BuiltMap<MediaType, OpenApiMediaType> content;
+  @override
+  final String? summary;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiResponse([void Function(OpenApiResponseBuilder)? updates]) =>
+      (new OpenApiResponseBuilder()..update(updates))._build();
+
+  _$OpenApiResponse._(
+      {this.statusCode,
+      required this.description,
+      required this.headers,
+      required this.content,
+      this.summary,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        description, r'OpenApiResponse', 'description');
+    BuiltValueNullFieldError.checkNotNull(
+        headers, r'OpenApiResponse', 'headers');
+    BuiltValueNullFieldError.checkNotNull(
+        content, r'OpenApiResponse', 'content');
+  }
+
+  @override
+  OpenApiResponse rebuild(void Function(OpenApiResponseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiResponseBuilder toBuilder() =>
+      new OpenApiResponseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiResponse &&
+        statusCode == other.statusCode &&
+        description == other.description &&
+        headers == other.headers &&
+        content == other.content &&
+        summary == other.summary &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, statusCode.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, headers.hashCode);
+    _$hash = $jc(_$hash, content.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiResponse')
+          ..add('statusCode', statusCode)
+          ..add('description', description)
+          ..add('headers', headers)
+          ..add('content', content)
+          ..add('summary', summary)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiResponseBuilder
+    implements
+        Builder<OpenApiResponse, OpenApiResponseBuilder>,
+        OpenApiComponentBuilder<OpenApiResponse> {
+  _$OpenApiResponse? _$v;
+
+  StatusCodeOrRange? _statusCode;
+  StatusCodeOrRange? get statusCode => _$this._statusCode;
+  set statusCode(covariant StatusCodeOrRange? statusCode) =>
+      _$this._statusCode = statusCode;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(covariant String? description) =>
+      _$this._description = description;
+
+  MapBuilder<String, OpenApiComponentOrRef<OpenApiHeader>>? _headers;
+  MapBuilder<String, OpenApiComponentOrRef<OpenApiHeader>> get headers =>
+      _$this._headers ??=
+          new MapBuilder<String, OpenApiComponentOrRef<OpenApiHeader>>();
+  set headers(
+          covariant MapBuilder<String, OpenApiComponentOrRef<OpenApiHeader>>?
+              headers) =>
+      _$this._headers = headers;
+
+  MapBuilder<MediaType, OpenApiMediaType>? _content;
+  MapBuilder<MediaType, OpenApiMediaType> get content =>
+      _$this._content ??= new MapBuilder<MediaType, OpenApiMediaType>();
+  set content(covariant MapBuilder<MediaType, OpenApiMediaType>? content) =>
+      _$this._content = content;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(covariant String? summary) => _$this._summary = summary;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(covariant String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(covariant YamlNode? node) => _$this._node = node;
+
+  OpenApiResponseBuilder();
+
+  OpenApiResponseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _statusCode = $v.statusCode;
+      _description = $v.description;
+      _headers = $v.headers.toBuilder();
+      _content = $v.content.toBuilder();
+      _summary = $v.summary;
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OpenApiResponse other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiResponse;
+  }
+
+  @override
+  void update(void Function(OpenApiResponseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiResponse build() => _build();
+
+  _$OpenApiResponse _build() {
+    _$OpenApiResponse _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiResponse._(
+            statusCode: statusCode,
+            description: BuiltValueNullFieldError.checkNotNull(
+                description, r'OpenApiResponse', 'description'),
+            headers: headers.build(),
+            content: content.build(),
+            summary: summary,
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'headers';
+        headers.build();
+        _$failedField = 'content';
+        content.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiResponse', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiHeader extends OpenApiHeader {
+  @override
+  final OpenApiComponentOrRef<OpenApiSchema> schema;
+  @override
+  final String? description;
+  @override
+  final bool required;
+  @override
+  final bool deprecated;
+  @override
+  final bool allowEmptyValue;
+  @override
+  final OpenApiParameterStyle? style;
+  @override
+  final bool? explode;
+  @override
+  final bool? allowReserved;
+  @override
+  final (MediaType, OpenApiMediaType)? content;
+  @override
+  final String? summary;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiHeader([void Function(OpenApiHeaderBuilder)? updates]) =>
+      (new OpenApiHeaderBuilder()..update(updates))._build();
+
+  _$OpenApiHeader._(
+      {required this.schema,
+      this.description,
+      required this.required,
+      required this.deprecated,
+      required this.allowEmptyValue,
+      this.style,
+      this.explode,
+      this.allowReserved,
+      this.content,
+      this.summary,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(schema, r'OpenApiHeader', 'schema');
+    BuiltValueNullFieldError.checkNotNull(
+        required, r'OpenApiHeader', 'required');
+    BuiltValueNullFieldError.checkNotNull(
+        deprecated, r'OpenApiHeader', 'deprecated');
+    BuiltValueNullFieldError.checkNotNull(
+        allowEmptyValue, r'OpenApiHeader', 'allowEmptyValue');
+  }
+
+  @override
+  OpenApiHeader rebuild(void Function(OpenApiHeaderBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiHeaderBuilder toBuilder() => new OpenApiHeaderBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    final dynamic _$dynamicOther = other;
+    return other is OpenApiHeader &&
+        schema == other.schema &&
+        description == other.description &&
+        required == other.required &&
+        deprecated == other.deprecated &&
+        allowEmptyValue == other.allowEmptyValue &&
+        style == other.style &&
+        explode == other.explode &&
+        allowReserved == other.allowReserved &&
+        content == _$dynamicOther.content &&
+        summary == other.summary &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, schema.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, required.hashCode);
+    _$hash = $jc(_$hash, deprecated.hashCode);
+    _$hash = $jc(_$hash, allowEmptyValue.hashCode);
+    _$hash = $jc(_$hash, style.hashCode);
+    _$hash = $jc(_$hash, explode.hashCode);
+    _$hash = $jc(_$hash, allowReserved.hashCode);
+    _$hash = $jc(_$hash, content.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiHeader')
+          ..add('schema', schema)
+          ..add('description', description)
+          ..add('required', required)
+          ..add('deprecated', deprecated)
+          ..add('allowEmptyValue', allowEmptyValue)
+          ..add('style', style)
+          ..add('explode', explode)
+          ..add('allowReserved', allowReserved)
+          ..add('content', content)
+          ..add('summary', summary)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiHeaderBuilder
+    implements
+        Builder<OpenApiHeader, OpenApiHeaderBuilder>,
+        OpenApiComponentBuilder<OpenApiHeader> {
+  _$OpenApiHeader? _$v;
+
+  OpenApiComponentOrRefBuilder<OpenApiSchema>? _schema;
+  OpenApiComponentOrRefBuilder<OpenApiSchema> get schema =>
+      _$this._schema ??= new OpenApiComponentOrRefBuilder<OpenApiSchema>();
+  set schema(covariant OpenApiComponentOrRefBuilder<OpenApiSchema>? schema) =>
+      _$this._schema = schema;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(covariant String? description) =>
+      _$this._description = description;
+
+  bool? _required;
+  bool? get required => _$this._required;
+  set required(covariant bool? required) => _$this._required = required;
+
+  bool? _deprecated;
+  bool? get deprecated => _$this._deprecated;
+  set deprecated(covariant bool? deprecated) => _$this._deprecated = deprecated;
+
+  bool? _allowEmptyValue;
+  bool? get allowEmptyValue => _$this._allowEmptyValue;
+  set allowEmptyValue(covariant bool? allowEmptyValue) =>
+      _$this._allowEmptyValue = allowEmptyValue;
+
+  OpenApiParameterStyle? _style;
+  OpenApiParameterStyle? get style => _$this._style;
+  set style(covariant OpenApiParameterStyle? style) => _$this._style = style;
+
+  bool? _explode;
+  bool? get explode => _$this._explode;
+  set explode(covariant bool? explode) => _$this._explode = explode;
+
+  bool? _allowReserved;
+  bool? get allowReserved => _$this._allowReserved;
+  set allowReserved(covariant bool? allowReserved) =>
+      _$this._allowReserved = allowReserved;
+
+  (MediaType, OpenApiMediaType)? _content;
+  (MediaType, OpenApiMediaType)? get content => _$this._content;
+  set content(covariant (MediaType, OpenApiMediaType)? content) =>
+      _$this._content = content;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(covariant String? summary) => _$this._summary = summary;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(covariant String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(covariant YamlNode? node) => _$this._node = node;
+
+  OpenApiHeaderBuilder();
+
+  OpenApiHeaderBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _schema = $v.schema.toBuilder();
+      _description = $v.description;
+      _required = $v.required;
+      _deprecated = $v.deprecated;
+      _allowEmptyValue = $v.allowEmptyValue;
+      _style = $v.style;
+      _explode = $v.explode;
+      _allowReserved = $v.allowReserved;
+      _content = $v.content;
+      _summary = $v.summary;
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OpenApiHeader other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiHeader;
+  }
+
+  @override
+  void update(void Function(OpenApiHeaderBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiHeader build() => _build();
+
+  _$OpenApiHeader _build() {
+    OpenApiHeader._validate(this);
+    _$OpenApiHeader _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiHeader._(
+            schema: schema.build(),
+            description: description,
+            required: BuiltValueNullFieldError.checkNotNull(
+                required, r'OpenApiHeader', 'required'),
+            deprecated: BuiltValueNullFieldError.checkNotNull(
+                deprecated, r'OpenApiHeader', 'deprecated'),
+            allowEmptyValue: BuiltValueNullFieldError.checkNotNull(
+                allowEmptyValue, r'OpenApiHeader', 'allowEmptyValue'),
+            style: style,
+            explode: explode,
+            allowReserved: allowReserved,
+            content: content,
+            summary: summary,
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'schema';
+        schema.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiHeader', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiComponents extends OpenApiComponents {
+  @override
+  final BuiltMap<String, OpenApiSchema> schemas;
+  @override
+  final BuiltMap<String, OpenApiResponse> responses;
+  @override
+  final BuiltMap<String, OpenApiParameter> parameters;
+  @override
+  final BuiltMap<String, OpenApiRequestBody> requestBodies;
+  @override
+  final BuiltMap<String, OpenApiHeader> headers;
+  @override
+  final BuiltMap<String, OpenApiSecurityScheme> securitySchemes;
+  @override
+  final BuiltMap<String, OpenApiPathItem> paths;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiComponents(
+          [void Function(OpenApiComponentsBuilder)? updates]) =>
+      (new OpenApiComponentsBuilder()..update(updates))._build();
+
+  _$OpenApiComponents._(
+      {required this.schemas,
+      required this.responses,
+      required this.parameters,
+      required this.requestBodies,
+      required this.headers,
+      required this.securitySchemes,
+      required this.paths,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        schemas, r'OpenApiComponents', 'schemas');
+    BuiltValueNullFieldError.checkNotNull(
+        responses, r'OpenApiComponents', 'responses');
+    BuiltValueNullFieldError.checkNotNull(
+        parameters, r'OpenApiComponents', 'parameters');
+    BuiltValueNullFieldError.checkNotNull(
+        requestBodies, r'OpenApiComponents', 'requestBodies');
+    BuiltValueNullFieldError.checkNotNull(
+        headers, r'OpenApiComponents', 'headers');
+    BuiltValueNullFieldError.checkNotNull(
+        securitySchemes, r'OpenApiComponents', 'securitySchemes');
+    BuiltValueNullFieldError.checkNotNull(paths, r'OpenApiComponents', 'paths');
+  }
+
+  @override
+  OpenApiComponents rebuild(void Function(OpenApiComponentsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiComponentsBuilder toBuilder() =>
+      new OpenApiComponentsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiComponents &&
+        schemas == other.schemas &&
+        responses == other.responses &&
+        parameters == other.parameters &&
+        requestBodies == other.requestBodies &&
+        headers == other.headers &&
+        securitySchemes == other.securitySchemes &&
+        paths == other.paths &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, schemas.hashCode);
+    _$hash = $jc(_$hash, responses.hashCode);
+    _$hash = $jc(_$hash, parameters.hashCode);
+    _$hash = $jc(_$hash, requestBodies.hashCode);
+    _$hash = $jc(_$hash, headers.hashCode);
+    _$hash = $jc(_$hash, securitySchemes.hashCode);
+    _$hash = $jc(_$hash, paths.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiComponents')
+          ..add('schemas', schemas)
+          ..add('responses', responses)
+          ..add('parameters', parameters)
+          ..add('requestBodies', requestBodies)
+          ..add('headers', headers)
+          ..add('securitySchemes', securitySchemes)
+          ..add('paths', paths)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiComponentsBuilder
+    implements Builder<OpenApiComponents, OpenApiComponentsBuilder> {
+  _$OpenApiComponents? _$v;
+
+  MapBuilder<String, OpenApiSchema>? _schemas;
+  MapBuilder<String, OpenApiSchema> get schemas =>
+      _$this._schemas ??= new MapBuilder<String, OpenApiSchema>();
+  set schemas(MapBuilder<String, OpenApiSchema>? schemas) =>
+      _$this._schemas = schemas;
+
+  MapBuilder<String, OpenApiResponse>? _responses;
+  MapBuilder<String, OpenApiResponse> get responses =>
+      _$this._responses ??= new MapBuilder<String, OpenApiResponse>();
+  set responses(MapBuilder<String, OpenApiResponse>? responses) =>
+      _$this._responses = responses;
+
+  MapBuilder<String, OpenApiParameter>? _parameters;
+  MapBuilder<String, OpenApiParameter> get parameters =>
+      _$this._parameters ??= new MapBuilder<String, OpenApiParameter>();
+  set parameters(MapBuilder<String, OpenApiParameter>? parameters) =>
+      _$this._parameters = parameters;
+
+  MapBuilder<String, OpenApiRequestBody>? _requestBodies;
+  MapBuilder<String, OpenApiRequestBody> get requestBodies =>
+      _$this._requestBodies ??= new MapBuilder<String, OpenApiRequestBody>();
+  set requestBodies(MapBuilder<String, OpenApiRequestBody>? requestBodies) =>
+      _$this._requestBodies = requestBodies;
+
+  MapBuilder<String, OpenApiHeader>? _headers;
+  MapBuilder<String, OpenApiHeader> get headers =>
+      _$this._headers ??= new MapBuilder<String, OpenApiHeader>();
+  set headers(MapBuilder<String, OpenApiHeader>? headers) =>
+      _$this._headers = headers;
+
+  MapBuilder<String, OpenApiSecurityScheme>? _securitySchemes;
+  MapBuilder<String, OpenApiSecurityScheme> get securitySchemes =>
+      _$this._securitySchemes ??=
+          new MapBuilder<String, OpenApiSecurityScheme>();
+  set securitySchemes(
+          MapBuilder<String, OpenApiSecurityScheme>? securitySchemes) =>
+      _$this._securitySchemes = securitySchemes;
+
+  MapBuilder<String, OpenApiPathItem>? _paths;
+  MapBuilder<String, OpenApiPathItem> get paths =>
+      _$this._paths ??= new MapBuilder<String, OpenApiPathItem>();
+  set paths(MapBuilder<String, OpenApiPathItem>? paths) =>
+      _$this._paths = paths;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiComponentsBuilder();
+
+  OpenApiComponentsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _schemas = $v.schemas.toBuilder();
+      _responses = $v.responses.toBuilder();
+      _parameters = $v.parameters.toBuilder();
+      _requestBodies = $v.requestBodies.toBuilder();
+      _headers = $v.headers.toBuilder();
+      _securitySchemes = $v.securitySchemes.toBuilder();
+      _paths = $v.paths.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiComponents other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiComponents;
+  }
+
+  @override
+  void update(void Function(OpenApiComponentsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiComponents build() => _build();
+
+  _$OpenApiComponents _build() {
+    _$OpenApiComponents _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiComponents._(
+            schemas: schemas.build(),
+            responses: responses.build(),
+            parameters: parameters.build(),
+            requestBodies: requestBodies.build(),
+            headers: headers.build(),
+            securitySchemes: securitySchemes.build(),
+            paths: paths.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'schemas';
+        schemas.build();
+        _$failedField = 'responses';
+        responses.build();
+        _$failedField = 'parameters';
+        parameters.build();
+        _$failedField = 'requestBodies';
+        requestBodies.build();
+        _$failedField = 'headers';
+        headers.build();
+        _$failedField = 'securitySchemes';
+        securitySchemes.build();
+        _$failedField = 'paths';
+        paths.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiComponents', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiSchema extends OpenApiSchema {
+  @override
+  final String? name;
+  @override
+  final ItemOrList<JsonType>? type;
+  @override
+  final bool? nullable;
+  @override
+  final BuiltList<OpenApiComponentOrRef<OpenApiSchema>>? allOf;
+  @override
+  final BuiltList<OpenApiComponentOrRef<OpenApiSchema>>? oneOf;
+  @override
+  final BuiltList<OpenApiComponentOrRef<OpenApiSchema>>? anyOf;
+  @override
+  final OpenApiComponentOrRef<OpenApiSchema>? items;
+  @override
+  final int? maxItems;
+  @override
+  final int? minItems;
+  @override
+  final bool? uniqueItems;
+  @override
+  final BuiltMap<String, OpenApiComponentOrRef<OpenApiSchema>>? properties;
+  @override
+  final OpenApiAdditionalProperties? additionalProperties;
+  @override
+  final int? maxProperties;
+  @override
+  final int? minProperties;
+  @override
+  final BuiltSet<String>? required;
+  @override
+  final JsonTypeFormat? format;
+  @override
+  final num? multipleOf;
+  @override
+  final num? maximum;
+  @override
+  final bool? exclusiveMaximum;
+  @override
+  final num? minimum;
+  @override
+  final bool? exclusiveMinimum;
+  @override
+  final int? maxLength;
+  @override
+  final int? minLength;
+  @override
+  final String? pattern;
+  @override
+  final BuiltSet<Object?>? enumValues;
+  @override
+  final OpenApiDiscriminator? discriminator;
+  @override
+  final String? title;
+  @override
+  final String? description;
+  @override
+  final bool? deprecated;
+  @override
+  final Object? defaultValue;
+  @override
+  final bool? readOnly;
+  @override
+  final bool? writeOnly;
+  @override
+  final BuiltMap<String, JsonObject>? extensions;
+  @override
+  final String? summary;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiSchema([void Function(OpenApiSchemaBuilder)? updates]) =>
+      (new OpenApiSchemaBuilder()..update(updates))._build();
+
+  _$OpenApiSchema._(
+      {this.name,
+      this.type,
+      this.nullable,
+      this.allOf,
+      this.oneOf,
+      this.anyOf,
+      this.items,
+      this.maxItems,
+      this.minItems,
+      this.uniqueItems,
+      this.properties,
+      this.additionalProperties,
+      this.maxProperties,
+      this.minProperties,
+      this.required,
+      this.format,
+      this.multipleOf,
+      this.maximum,
+      this.exclusiveMaximum,
+      this.minimum,
+      this.exclusiveMinimum,
+      this.maxLength,
+      this.minLength,
+      this.pattern,
+      this.enumValues,
+      this.discriminator,
+      this.title,
+      this.description,
+      this.deprecated,
+      this.defaultValue,
+      this.readOnly,
+      this.writeOnly,
+      this.extensions,
+      this.summary,
+      this.ref,
+      this.node})
+      : super._();
+
+  @override
+  OpenApiSchema rebuild(void Function(OpenApiSchemaBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiSchemaBuilder toBuilder() => new OpenApiSchemaBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiSchema &&
+        name == other.name &&
+        type == other.type &&
+        nullable == other.nullable &&
+        allOf == other.allOf &&
+        oneOf == other.oneOf &&
+        anyOf == other.anyOf &&
+        items == other.items &&
+        maxItems == other.maxItems &&
+        minItems == other.minItems &&
+        uniqueItems == other.uniqueItems &&
+        properties == other.properties &&
+        additionalProperties == other.additionalProperties &&
+        maxProperties == other.maxProperties &&
+        minProperties == other.minProperties &&
+        required == other.required &&
+        format == other.format &&
+        multipleOf == other.multipleOf &&
+        maximum == other.maximum &&
+        exclusiveMaximum == other.exclusiveMaximum &&
+        minimum == other.minimum &&
+        exclusiveMinimum == other.exclusiveMinimum &&
+        maxLength == other.maxLength &&
+        minLength == other.minLength &&
+        pattern == other.pattern &&
+        enumValues == other.enumValues &&
+        discriminator == other.discriminator &&
+        title == other.title &&
+        description == other.description &&
+        deprecated == other.deprecated &&
+        defaultValue == other.defaultValue &&
+        readOnly == other.readOnly &&
+        writeOnly == other.writeOnly &&
+        extensions == other.extensions &&
+        summary == other.summary &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, type.hashCode);
+    _$hash = $jc(_$hash, nullable.hashCode);
+    _$hash = $jc(_$hash, allOf.hashCode);
+    _$hash = $jc(_$hash, oneOf.hashCode);
+    _$hash = $jc(_$hash, anyOf.hashCode);
+    _$hash = $jc(_$hash, items.hashCode);
+    _$hash = $jc(_$hash, maxItems.hashCode);
+    _$hash = $jc(_$hash, minItems.hashCode);
+    _$hash = $jc(_$hash, uniqueItems.hashCode);
+    _$hash = $jc(_$hash, properties.hashCode);
+    _$hash = $jc(_$hash, additionalProperties.hashCode);
+    _$hash = $jc(_$hash, maxProperties.hashCode);
+    _$hash = $jc(_$hash, minProperties.hashCode);
+    _$hash = $jc(_$hash, required.hashCode);
+    _$hash = $jc(_$hash, format.hashCode);
+    _$hash = $jc(_$hash, multipleOf.hashCode);
+    _$hash = $jc(_$hash, maximum.hashCode);
+    _$hash = $jc(_$hash, exclusiveMaximum.hashCode);
+    _$hash = $jc(_$hash, minimum.hashCode);
+    _$hash = $jc(_$hash, exclusiveMinimum.hashCode);
+    _$hash = $jc(_$hash, maxLength.hashCode);
+    _$hash = $jc(_$hash, minLength.hashCode);
+    _$hash = $jc(_$hash, pattern.hashCode);
+    _$hash = $jc(_$hash, enumValues.hashCode);
+    _$hash = $jc(_$hash, discriminator.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, deprecated.hashCode);
+    _$hash = $jc(_$hash, defaultValue.hashCode);
+    _$hash = $jc(_$hash, readOnly.hashCode);
+    _$hash = $jc(_$hash, writeOnly.hashCode);
+    _$hash = $jc(_$hash, extensions.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiSchema')
+          ..add('name', name)
+          ..add('type', type)
+          ..add('nullable', nullable)
+          ..add('allOf', allOf)
+          ..add('oneOf', oneOf)
+          ..add('anyOf', anyOf)
+          ..add('items', items)
+          ..add('maxItems', maxItems)
+          ..add('minItems', minItems)
+          ..add('uniqueItems', uniqueItems)
+          ..add('properties', properties)
+          ..add('additionalProperties', additionalProperties)
+          ..add('maxProperties', maxProperties)
+          ..add('minProperties', minProperties)
+          ..add('required', required)
+          ..add('format', format)
+          ..add('multipleOf', multipleOf)
+          ..add('maximum', maximum)
+          ..add('exclusiveMaximum', exclusiveMaximum)
+          ..add('minimum', minimum)
+          ..add('exclusiveMinimum', exclusiveMinimum)
+          ..add('maxLength', maxLength)
+          ..add('minLength', minLength)
+          ..add('pattern', pattern)
+          ..add('enumValues', enumValues)
+          ..add('discriminator', discriminator)
+          ..add('title', title)
+          ..add('description', description)
+          ..add('deprecated', deprecated)
+          ..add('defaultValue', defaultValue)
+          ..add('readOnly', readOnly)
+          ..add('writeOnly', writeOnly)
+          ..add('extensions', extensions)
+          ..add('summary', summary)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiSchemaBuilder
+    implements
+        Builder<OpenApiSchema, OpenApiSchemaBuilder>,
+        OpenApiComponentBuilder<OpenApiSchema> {
+  _$OpenApiSchema? _$v;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  ItemOrList<JsonType>? _type;
+  ItemOrList<JsonType>? get type => _$this._type;
+  set type(covariant ItemOrList<JsonType>? type) => _$this._type = type;
+
+  bool? _nullable;
+  bool? get nullable => _$this._nullable;
+  set nullable(covariant bool? nullable) => _$this._nullable = nullable;
+
+  ListBuilder<OpenApiComponentOrRef<OpenApiSchema>>? _allOf;
+  ListBuilder<OpenApiComponentOrRef<OpenApiSchema>> get allOf =>
+      _$this._allOf ??= new ListBuilder<OpenApiComponentOrRef<OpenApiSchema>>();
+  set allOf(
+          covariant ListBuilder<OpenApiComponentOrRef<OpenApiSchema>>? allOf) =>
+      _$this._allOf = allOf;
+
+  ListBuilder<OpenApiComponentOrRef<OpenApiSchema>>? _oneOf;
+  ListBuilder<OpenApiComponentOrRef<OpenApiSchema>> get oneOf =>
+      _$this._oneOf ??= new ListBuilder<OpenApiComponentOrRef<OpenApiSchema>>();
+  set oneOf(
+          covariant ListBuilder<OpenApiComponentOrRef<OpenApiSchema>>? oneOf) =>
+      _$this._oneOf = oneOf;
+
+  ListBuilder<OpenApiComponentOrRef<OpenApiSchema>>? _anyOf;
+  ListBuilder<OpenApiComponentOrRef<OpenApiSchema>> get anyOf =>
+      _$this._anyOf ??= new ListBuilder<OpenApiComponentOrRef<OpenApiSchema>>();
+  set anyOf(
+          covariant ListBuilder<OpenApiComponentOrRef<OpenApiSchema>>? anyOf) =>
+      _$this._anyOf = anyOf;
+
+  OpenApiComponentOrRefBuilder<OpenApiSchema>? _items;
+  OpenApiComponentOrRefBuilder<OpenApiSchema> get items =>
+      _$this._items ??= new OpenApiComponentOrRefBuilder<OpenApiSchema>();
+  set items(covariant OpenApiComponentOrRefBuilder<OpenApiSchema>? items) =>
+      _$this._items = items;
+
+  int? _maxItems;
+  int? get maxItems => _$this._maxItems;
+  set maxItems(covariant int? maxItems) => _$this._maxItems = maxItems;
+
+  int? _minItems;
+  int? get minItems => _$this._minItems;
+  set minItems(covariant int? minItems) => _$this._minItems = minItems;
+
+  bool? _uniqueItems;
+  bool? get uniqueItems => _$this._uniqueItems;
+  set uniqueItems(covariant bool? uniqueItems) =>
+      _$this._uniqueItems = uniqueItems;
+
+  MapBuilder<String, OpenApiComponentOrRef<OpenApiSchema>>? _properties;
+  MapBuilder<String, OpenApiComponentOrRef<OpenApiSchema>> get properties =>
+      _$this._properties ??=
+          new MapBuilder<String, OpenApiComponentOrRef<OpenApiSchema>>();
+  set properties(
+          covariant MapBuilder<String, OpenApiComponentOrRef<OpenApiSchema>>?
+              properties) =>
+      _$this._properties = properties;
+
+  OpenApiAdditionalPropertiesBuilder? _additionalProperties;
+  OpenApiAdditionalPropertiesBuilder get additionalProperties =>
+      _$this._additionalProperties ??= new OpenApiAdditionalPropertiesBuilder();
+  set additionalProperties(
+          covariant OpenApiAdditionalPropertiesBuilder? additionalProperties) =>
+      _$this._additionalProperties = additionalProperties;
+
+  int? _maxProperties;
+  int? get maxProperties => _$this._maxProperties;
+  set maxProperties(covariant int? maxProperties) =>
+      _$this._maxProperties = maxProperties;
+
+  int? _minProperties;
+  int? get minProperties => _$this._minProperties;
+  set minProperties(covariant int? minProperties) =>
+      _$this._minProperties = minProperties;
+
+  SetBuilder<String>? _required;
+  SetBuilder<String> get required =>
+      _$this._required ??= new SetBuilder<String>();
+  set required(covariant SetBuilder<String>? required) =>
+      _$this._required = required;
+
+  JsonTypeFormat? _format;
+  JsonTypeFormat? get format => _$this._format;
+  set format(covariant JsonTypeFormat? format) => _$this._format = format;
+
+  num? _multipleOf;
+  num? get multipleOf => _$this._multipleOf;
+  set multipleOf(covariant num? multipleOf) => _$this._multipleOf = multipleOf;
+
+  num? _maximum;
+  num? get maximum => _$this._maximum;
+  set maximum(covariant num? maximum) => _$this._maximum = maximum;
+
+  bool? _exclusiveMaximum;
+  bool? get exclusiveMaximum => _$this._exclusiveMaximum;
+  set exclusiveMaximum(covariant bool? exclusiveMaximum) =>
+      _$this._exclusiveMaximum = exclusiveMaximum;
+
+  num? _minimum;
+  num? get minimum => _$this._minimum;
+  set minimum(covariant num? minimum) => _$this._minimum = minimum;
+
+  bool? _exclusiveMinimum;
+  bool? get exclusiveMinimum => _$this._exclusiveMinimum;
+  set exclusiveMinimum(covariant bool? exclusiveMinimum) =>
+      _$this._exclusiveMinimum = exclusiveMinimum;
+
+  int? _maxLength;
+  int? get maxLength => _$this._maxLength;
+  set maxLength(covariant int? maxLength) => _$this._maxLength = maxLength;
+
+  int? _minLength;
+  int? get minLength => _$this._minLength;
+  set minLength(covariant int? minLength) => _$this._minLength = minLength;
+
+  String? _pattern;
+  String? get pattern => _$this._pattern;
+  set pattern(covariant String? pattern) => _$this._pattern = pattern;
+
+  SetBuilder<Object?>? _enumValues;
+  SetBuilder<Object?> get enumValues =>
+      _$this._enumValues ??= new SetBuilder<Object?>();
+  set enumValues(covariant SetBuilder<Object?>? enumValues) =>
+      _$this._enumValues = enumValues;
+
+  OpenApiDiscriminatorBuilder? _discriminator;
+  OpenApiDiscriminatorBuilder get discriminator =>
+      _$this._discriminator ??= new OpenApiDiscriminatorBuilder();
+  set discriminator(covariant OpenApiDiscriminatorBuilder? discriminator) =>
+      _$this._discriminator = discriminator;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(covariant String? title) => _$this._title = title;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(covariant String? description) =>
+      _$this._description = description;
+
+  bool? _deprecated;
+  bool? get deprecated => _$this._deprecated;
+  set deprecated(covariant bool? deprecated) => _$this._deprecated = deprecated;
+
+  Object? _defaultValue;
+  Object? get defaultValue => _$this._defaultValue;
+  set defaultValue(covariant Object? defaultValue) =>
+      _$this._defaultValue = defaultValue;
+
+  bool? _readOnly;
+  bool? get readOnly => _$this._readOnly;
+  set readOnly(covariant bool? readOnly) => _$this._readOnly = readOnly;
+
+  bool? _writeOnly;
+  bool? get writeOnly => _$this._writeOnly;
+  set writeOnly(covariant bool? writeOnly) => _$this._writeOnly = writeOnly;
+
+  MapBuilder<String, JsonObject>? _extensions;
+  MapBuilder<String, JsonObject> get extensions =>
+      _$this._extensions ??= new MapBuilder<String, JsonObject>();
+  set extensions(covariant MapBuilder<String, JsonObject>? extensions) =>
+      _$this._extensions = extensions;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(covariant String? summary) => _$this._summary = summary;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(covariant String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(covariant YamlNode? node) => _$this._node = node;
+
+  OpenApiSchemaBuilder();
+
+  OpenApiSchemaBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _name = $v.name;
+      _type = $v.type;
+      _nullable = $v.nullable;
+      _allOf = $v.allOf?.toBuilder();
+      _oneOf = $v.oneOf?.toBuilder();
+      _anyOf = $v.anyOf?.toBuilder();
+      _items = $v.items?.toBuilder();
+      _maxItems = $v.maxItems;
+      _minItems = $v.minItems;
+      _uniqueItems = $v.uniqueItems;
+      _properties = $v.properties?.toBuilder();
+      _additionalProperties = $v.additionalProperties?.toBuilder();
+      _maxProperties = $v.maxProperties;
+      _minProperties = $v.minProperties;
+      _required = $v.required?.toBuilder();
+      _format = $v.format;
+      _multipleOf = $v.multipleOf;
+      _maximum = $v.maximum;
+      _exclusiveMaximum = $v.exclusiveMaximum;
+      _minimum = $v.minimum;
+      _exclusiveMinimum = $v.exclusiveMinimum;
+      _maxLength = $v.maxLength;
+      _minLength = $v.minLength;
+      _pattern = $v.pattern;
+      _enumValues = $v.enumValues?.toBuilder();
+      _discriminator = $v.discriminator?.toBuilder();
+      _title = $v.title;
+      _description = $v.description;
+      _deprecated = $v.deprecated;
+      _defaultValue = $v.defaultValue;
+      _readOnly = $v.readOnly;
+      _writeOnly = $v.writeOnly;
+      _extensions = $v.extensions?.toBuilder();
+      _summary = $v.summary;
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OpenApiSchema other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiSchema;
+  }
+
+  @override
+  void update(void Function(OpenApiSchemaBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiSchema build() => _build();
+
+  _$OpenApiSchema _build() {
+    _$OpenApiSchema _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiSchema._(
+            name: name,
+            type: type,
+            nullable: nullable,
+            allOf: _allOf?.build(),
+            oneOf: _oneOf?.build(),
+            anyOf: _anyOf?.build(),
+            items: _items?.build(),
+            maxItems: maxItems,
+            minItems: minItems,
+            uniqueItems: uniqueItems,
+            properties: _properties?.build(),
+            additionalProperties: _additionalProperties?.build(),
+            maxProperties: maxProperties,
+            minProperties: minProperties,
+            required: _required?.build(),
+            format: format,
+            multipleOf: multipleOf,
+            maximum: maximum,
+            exclusiveMaximum: exclusiveMaximum,
+            minimum: minimum,
+            exclusiveMinimum: exclusiveMinimum,
+            maxLength: maxLength,
+            minLength: minLength,
+            pattern: pattern,
+            enumValues: _enumValues?.build(),
+            discriminator: _discriminator?.build(),
+            title: title,
+            description: description,
+            deprecated: deprecated,
+            defaultValue: defaultValue,
+            readOnly: readOnly,
+            writeOnly: writeOnly,
+            extensions: _extensions?.build(),
+            summary: summary,
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'allOf';
+        _allOf?.build();
+        _$failedField = 'oneOf';
+        _oneOf?.build();
+        _$failedField = 'anyOf';
+        _anyOf?.build();
+        _$failedField = 'items';
+        _items?.build();
+
+        _$failedField = 'properties';
+        _properties?.build();
+        _$failedField = 'additionalProperties';
+        _additionalProperties?.build();
+
+        _$failedField = 'required';
+        _required?.build();
+
+        _$failedField = 'enumValues';
+        _enumValues?.build();
+        _$failedField = 'discriminator';
+        _discriminator?.build();
+
+        _$failedField = 'extensions';
+        _extensions?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiSchema', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiAdditionalProperties extends OpenApiAdditionalProperties {
+  @override
+  final bool? allow;
+  @override
+  final OpenApiComponentOrRef<OpenApiSchema>? schema;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiAdditionalProperties(
+          [void Function(OpenApiAdditionalPropertiesBuilder)? updates]) =>
+      (new OpenApiAdditionalPropertiesBuilder()..update(updates))._build();
+
+  _$OpenApiAdditionalProperties._(
+      {this.allow, this.schema, this.ref, this.node})
+      : super._();
+
+  @override
+  OpenApiAdditionalProperties rebuild(
+          void Function(OpenApiAdditionalPropertiesBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiAdditionalPropertiesBuilder toBuilder() =>
+      new OpenApiAdditionalPropertiesBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiAdditionalProperties &&
+        allow == other.allow &&
+        schema == other.schema &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, allow.hashCode);
+    _$hash = $jc(_$hash, schema.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiAdditionalProperties')
+          ..add('allow', allow)
+          ..add('schema', schema)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiAdditionalPropertiesBuilder
+    implements
+        Builder<OpenApiAdditionalProperties,
+            OpenApiAdditionalPropertiesBuilder> {
+  _$OpenApiAdditionalProperties? _$v;
+
+  bool? _allow;
+  bool? get allow => _$this._allow;
+  set allow(bool? allow) => _$this._allow = allow;
+
+  OpenApiComponentOrRefBuilder<OpenApiSchema>? _schema;
+  OpenApiComponentOrRefBuilder<OpenApiSchema> get schema =>
+      _$this._schema ??= new OpenApiComponentOrRefBuilder<OpenApiSchema>();
+  set schema(OpenApiComponentOrRefBuilder<OpenApiSchema>? schema) =>
+      _$this._schema = schema;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiAdditionalPropertiesBuilder();
+
+  OpenApiAdditionalPropertiesBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _allow = $v.allow;
+      _schema = $v.schema?.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiAdditionalProperties other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiAdditionalProperties;
+  }
+
+  @override
+  void update(void Function(OpenApiAdditionalPropertiesBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiAdditionalProperties build() => _build();
+
+  _$OpenApiAdditionalProperties _build() {
+    _$OpenApiAdditionalProperties _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiAdditionalProperties._(
+            allow: allow,
+            schema: _schema?.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'schema';
+        _schema?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiAdditionalProperties', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiDiscriminator extends OpenApiDiscriminator {
+  @override
+  final String propertyName;
+  @override
+  final BuiltMap<String, String>? mapping;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiDiscriminator(
+          [void Function(OpenApiDiscriminatorBuilder)? updates]) =>
+      (new OpenApiDiscriminatorBuilder()..update(updates))._build();
+
+  _$OpenApiDiscriminator._(
+      {required this.propertyName, this.mapping, this.ref, this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        propertyName, r'OpenApiDiscriminator', 'propertyName');
+  }
+
+  @override
+  OpenApiDiscriminator rebuild(
+          void Function(OpenApiDiscriminatorBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiDiscriminatorBuilder toBuilder() =>
+      new OpenApiDiscriminatorBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiDiscriminator &&
+        propertyName == other.propertyName &&
+        mapping == other.mapping &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, propertyName.hashCode);
+    _$hash = $jc(_$hash, mapping.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiDiscriminator')
+          ..add('propertyName', propertyName)
+          ..add('mapping', mapping)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiDiscriminatorBuilder
+    implements Builder<OpenApiDiscriminator, OpenApiDiscriminatorBuilder> {
+  _$OpenApiDiscriminator? _$v;
+
+  String? _propertyName;
+  String? get propertyName => _$this._propertyName;
+  set propertyName(String? propertyName) => _$this._propertyName = propertyName;
+
+  MapBuilder<String, String>? _mapping;
+  MapBuilder<String, String> get mapping =>
+      _$this._mapping ??= new MapBuilder<String, String>();
+  set mapping(MapBuilder<String, String>? mapping) => _$this._mapping = mapping;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiDiscriminatorBuilder();
+
+  OpenApiDiscriminatorBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _propertyName = $v.propertyName;
+      _mapping = $v.mapping?.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiDiscriminator other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiDiscriminator;
+  }
+
+  @override
+  void update(void Function(OpenApiDiscriminatorBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiDiscriminator build() => _build();
+
+  _$OpenApiDiscriminator _build() {
+    _$OpenApiDiscriminator _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiDiscriminator._(
+            propertyName: BuiltValueNullFieldError.checkNotNull(
+                propertyName, r'OpenApiDiscriminator', 'propertyName'),
+            mapping: _mapping?.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'mapping';
+        _mapping?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiDiscriminator', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiSecurityScheme extends OpenApiSecurityScheme {
+  @override
+  final OpenApiSecuritySchemeType type;
+  @override
+  final String? description;
+  @override
+  final String? name;
+  @override
+  final OpenApiParameterLocation? location;
+  @override
+  final String? scheme;
+  @override
+  final String? bearerFormat;
+  @override
+  final OpenApiOAuthFlows? flows;
+  @override
+  final String? openIdConnectUrl;
+  @override
+  final String? summary;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiSecurityScheme(
+          [void Function(OpenApiSecuritySchemeBuilder)? updates]) =>
+      (new OpenApiSecuritySchemeBuilder()..update(updates))._build();
+
+  _$OpenApiSecurityScheme._(
+      {required this.type,
+      this.description,
+      this.name,
+      this.location,
+      this.scheme,
+      this.bearerFormat,
+      this.flows,
+      this.openIdConnectUrl,
+      this.summary,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        type, r'OpenApiSecurityScheme', 'type');
+  }
+
+  @override
+  OpenApiSecurityScheme rebuild(
+          void Function(OpenApiSecuritySchemeBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiSecuritySchemeBuilder toBuilder() =>
+      new OpenApiSecuritySchemeBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiSecurityScheme &&
+        type == other.type &&
+        description == other.description &&
+        name == other.name &&
+        location == other.location &&
+        scheme == other.scheme &&
+        bearerFormat == other.bearerFormat &&
+        flows == other.flows &&
+        openIdConnectUrl == other.openIdConnectUrl &&
+        summary == other.summary &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, type.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, location.hashCode);
+    _$hash = $jc(_$hash, scheme.hashCode);
+    _$hash = $jc(_$hash, bearerFormat.hashCode);
+    _$hash = $jc(_$hash, flows.hashCode);
+    _$hash = $jc(_$hash, openIdConnectUrl.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiSecurityScheme')
+          ..add('type', type)
+          ..add('description', description)
+          ..add('name', name)
+          ..add('location', location)
+          ..add('scheme', scheme)
+          ..add('bearerFormat', bearerFormat)
+          ..add('flows', flows)
+          ..add('openIdConnectUrl', openIdConnectUrl)
+          ..add('summary', summary)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiSecuritySchemeBuilder
+    implements
+        Builder<OpenApiSecurityScheme, OpenApiSecuritySchemeBuilder>,
+        OpenApiComponentBuilder<OpenApiSecurityScheme> {
+  _$OpenApiSecurityScheme? _$v;
+
+  OpenApiSecuritySchemeType? _type;
+  OpenApiSecuritySchemeType? get type => _$this._type;
+  set type(covariant OpenApiSecuritySchemeType? type) => _$this._type = type;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(covariant String? description) =>
+      _$this._description = description;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  OpenApiParameterLocation? _location;
+  OpenApiParameterLocation? get location => _$this._location;
+  set location(covariant OpenApiParameterLocation? location) =>
+      _$this._location = location;
+
+  String? _scheme;
+  String? get scheme => _$this._scheme;
+  set scheme(covariant String? scheme) => _$this._scheme = scheme;
+
+  String? _bearerFormat;
+  String? get bearerFormat => _$this._bearerFormat;
+  set bearerFormat(covariant String? bearerFormat) =>
+      _$this._bearerFormat = bearerFormat;
+
+  OpenApiOAuthFlowsBuilder? _flows;
+  OpenApiOAuthFlowsBuilder get flows =>
+      _$this._flows ??= new OpenApiOAuthFlowsBuilder();
+  set flows(covariant OpenApiOAuthFlowsBuilder? flows) => _$this._flows = flows;
+
+  String? _openIdConnectUrl;
+  String? get openIdConnectUrl => _$this._openIdConnectUrl;
+  set openIdConnectUrl(covariant String? openIdConnectUrl) =>
+      _$this._openIdConnectUrl = openIdConnectUrl;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(covariant String? summary) => _$this._summary = summary;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(covariant String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(covariant YamlNode? node) => _$this._node = node;
+
+  OpenApiSecuritySchemeBuilder();
+
+  OpenApiSecuritySchemeBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _type = $v.type;
+      _description = $v.description;
+      _name = $v.name;
+      _location = $v.location;
+      _scheme = $v.scheme;
+      _bearerFormat = $v.bearerFormat;
+      _flows = $v.flows?.toBuilder();
+      _openIdConnectUrl = $v.openIdConnectUrl;
+      _summary = $v.summary;
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OpenApiSecurityScheme other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiSecurityScheme;
+  }
+
+  @override
+  void update(void Function(OpenApiSecuritySchemeBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiSecurityScheme build() => _build();
+
+  _$OpenApiSecurityScheme _build() {
+    OpenApiSecurityScheme._validate(this);
+    _$OpenApiSecurityScheme _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiSecurityScheme._(
+            type: BuiltValueNullFieldError.checkNotNull(
+                type, r'OpenApiSecurityScheme', 'type'),
+            description: description,
+            name: name,
+            location: location,
+            scheme: scheme,
+            bearerFormat: bearerFormat,
+            flows: _flows?.build(),
+            openIdConnectUrl: openIdConnectUrl,
+            summary: summary,
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'flows';
+        _flows?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiSecurityScheme', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiOAuthFlows extends OpenApiOAuthFlows {
+  @override
+  final OpenApiOAuthFlow? implicit;
+  @override
+  final OpenApiOAuthFlow? password;
+  @override
+  final OpenApiOAuthFlow? clientCredentials;
+  @override
+  final OpenApiOAuthFlow? authorizationCode;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiOAuthFlows(
+          [void Function(OpenApiOAuthFlowsBuilder)? updates]) =>
+      (new OpenApiOAuthFlowsBuilder()..update(updates))._build();
+
+  _$OpenApiOAuthFlows._(
+      {this.implicit,
+      this.password,
+      this.clientCredentials,
+      this.authorizationCode,
+      this.ref,
+      this.node})
+      : super._();
+
+  @override
+  OpenApiOAuthFlows rebuild(void Function(OpenApiOAuthFlowsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiOAuthFlowsBuilder toBuilder() =>
+      new OpenApiOAuthFlowsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiOAuthFlows &&
+        implicit == other.implicit &&
+        password == other.password &&
+        clientCredentials == other.clientCredentials &&
+        authorizationCode == other.authorizationCode &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, implicit.hashCode);
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jc(_$hash, clientCredentials.hashCode);
+    _$hash = $jc(_$hash, authorizationCode.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiOAuthFlows')
+          ..add('implicit', implicit)
+          ..add('password', password)
+          ..add('clientCredentials', clientCredentials)
+          ..add('authorizationCode', authorizationCode)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiOAuthFlowsBuilder
+    implements Builder<OpenApiOAuthFlows, OpenApiOAuthFlowsBuilder> {
+  _$OpenApiOAuthFlows? _$v;
+
+  OpenApiOAuthFlowBuilder? _implicit;
+  OpenApiOAuthFlowBuilder get implicit =>
+      _$this._implicit ??= new OpenApiOAuthFlowBuilder();
+  set implicit(OpenApiOAuthFlowBuilder? implicit) =>
+      _$this._implicit = implicit;
+
+  OpenApiOAuthFlowBuilder? _password;
+  OpenApiOAuthFlowBuilder get password =>
+      _$this._password ??= new OpenApiOAuthFlowBuilder();
+  set password(OpenApiOAuthFlowBuilder? password) =>
+      _$this._password = password;
+
+  OpenApiOAuthFlowBuilder? _clientCredentials;
+  OpenApiOAuthFlowBuilder get clientCredentials =>
+      _$this._clientCredentials ??= new OpenApiOAuthFlowBuilder();
+  set clientCredentials(OpenApiOAuthFlowBuilder? clientCredentials) =>
+      _$this._clientCredentials = clientCredentials;
+
+  OpenApiOAuthFlowBuilder? _authorizationCode;
+  OpenApiOAuthFlowBuilder get authorizationCode =>
+      _$this._authorizationCode ??= new OpenApiOAuthFlowBuilder();
+  set authorizationCode(OpenApiOAuthFlowBuilder? authorizationCode) =>
+      _$this._authorizationCode = authorizationCode;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiOAuthFlowsBuilder();
+
+  OpenApiOAuthFlowsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _implicit = $v.implicit?.toBuilder();
+      _password = $v.password?.toBuilder();
+      _clientCredentials = $v.clientCredentials?.toBuilder();
+      _authorizationCode = $v.authorizationCode?.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiOAuthFlows other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiOAuthFlows;
+  }
+
+  @override
+  void update(void Function(OpenApiOAuthFlowsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiOAuthFlows build() => _build();
+
+  _$OpenApiOAuthFlows _build() {
+    OpenApiOAuthFlows._validate(this);
+    _$OpenApiOAuthFlows _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiOAuthFlows._(
+            implicit: _implicit?.build(),
+            password: _password?.build(),
+            clientCredentials: _clientCredentials?.build(),
+            authorizationCode: _authorizationCode?.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'implicit';
+        _implicit?.build();
+        _$failedField = 'password';
+        _password?.build();
+        _$failedField = 'clientCredentials';
+        _clientCredentials?.build();
+        _$failedField = 'authorizationCode';
+        _authorizationCode?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiOAuthFlows', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiOAuthFlow extends OpenApiOAuthFlow {
+  @override
+  final String? authorizationUrl;
+  @override
+  final String? tokenUrl;
+  @override
+  final String? refreshUrl;
+  @override
+  final BuiltMap<String, String> scopes;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiOAuthFlow(
+          [void Function(OpenApiOAuthFlowBuilder)? updates]) =>
+      (new OpenApiOAuthFlowBuilder()..update(updates))._build();
+
+  _$OpenApiOAuthFlow._(
+      {this.authorizationUrl,
+      this.tokenUrl,
+      this.refreshUrl,
+      required this.scopes,
+      this.ref,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        scopes, r'OpenApiOAuthFlow', 'scopes');
+  }
+
+  @override
+  OpenApiOAuthFlow rebuild(void Function(OpenApiOAuthFlowBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiOAuthFlowBuilder toBuilder() =>
+      new OpenApiOAuthFlowBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiOAuthFlow &&
+        authorizationUrl == other.authorizationUrl &&
+        tokenUrl == other.tokenUrl &&
+        refreshUrl == other.refreshUrl &&
+        scopes == other.scopes &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, authorizationUrl.hashCode);
+    _$hash = $jc(_$hash, tokenUrl.hashCode);
+    _$hash = $jc(_$hash, refreshUrl.hashCode);
+    _$hash = $jc(_$hash, scopes.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiOAuthFlow')
+          ..add('authorizationUrl', authorizationUrl)
+          ..add('tokenUrl', tokenUrl)
+          ..add('refreshUrl', refreshUrl)
+          ..add('scopes', scopes)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiOAuthFlowBuilder
+    implements Builder<OpenApiOAuthFlow, OpenApiOAuthFlowBuilder> {
+  _$OpenApiOAuthFlow? _$v;
+
+  String? _authorizationUrl;
+  String? get authorizationUrl => _$this._authorizationUrl;
+  set authorizationUrl(String? authorizationUrl) =>
+      _$this._authorizationUrl = authorizationUrl;
+
+  String? _tokenUrl;
+  String? get tokenUrl => _$this._tokenUrl;
+  set tokenUrl(String? tokenUrl) => _$this._tokenUrl = tokenUrl;
+
+  String? _refreshUrl;
+  String? get refreshUrl => _$this._refreshUrl;
+  set refreshUrl(String? refreshUrl) => _$this._refreshUrl = refreshUrl;
+
+  MapBuilder<String, String>? _scopes;
+  MapBuilder<String, String> get scopes =>
+      _$this._scopes ??= new MapBuilder<String, String>();
+  set scopes(MapBuilder<String, String>? scopes) => _$this._scopes = scopes;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiOAuthFlowBuilder();
+
+  OpenApiOAuthFlowBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _authorizationUrl = $v.authorizationUrl;
+      _tokenUrl = $v.tokenUrl;
+      _refreshUrl = $v.refreshUrl;
+      _scopes = $v.scopes.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiOAuthFlow other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiOAuthFlow;
+  }
+
+  @override
+  void update(void Function(OpenApiOAuthFlowBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiOAuthFlow build() => _build();
+
+  _$OpenApiOAuthFlow _build() {
+    _$OpenApiOAuthFlow _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiOAuthFlow._(
+            authorizationUrl: authorizationUrl,
+            tokenUrl: tokenUrl,
+            refreshUrl: refreshUrl,
+            scopes: scopes.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'scopes';
+        scopes.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiOAuthFlow', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiSecurityRequirement extends OpenApiSecurityRequirement {
+  @override
+  final BuiltMap<String, BuiltList<String>> schemes;
+  @override
+  final String? ref;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiSecurityRequirement(
+          [void Function(OpenApiSecurityRequirementBuilder)? updates]) =>
+      (new OpenApiSecurityRequirementBuilder()..update(updates))._build();
+
+  _$OpenApiSecurityRequirement._({required this.schemes, this.ref, this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        schemes, r'OpenApiSecurityRequirement', 'schemes');
+  }
+
+  @override
+  OpenApiSecurityRequirement rebuild(
+          void Function(OpenApiSecurityRequirementBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiSecurityRequirementBuilder toBuilder() =>
+      new OpenApiSecurityRequirementBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiSecurityRequirement &&
+        schemes == other.schemes &&
+        ref == other.ref &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, schemes.hashCode);
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiSecurityRequirement')
+          ..add('schemes', schemes)
+          ..add('ref', ref)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiSecurityRequirementBuilder
+    implements
+        Builder<OpenApiSecurityRequirement, OpenApiSecurityRequirementBuilder> {
+  _$OpenApiSecurityRequirement? _$v;
+
+  MapBuilder<String, BuiltList<String>>? _schemes;
+  MapBuilder<String, BuiltList<String>> get schemes =>
+      _$this._schemes ??= new MapBuilder<String, BuiltList<String>>();
+  set schemes(MapBuilder<String, BuiltList<String>>? schemes) =>
+      _$this._schemes = schemes;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiSecurityRequirementBuilder();
+
+  OpenApiSecurityRequirementBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _schemes = $v.schemes.toBuilder();
+      _ref = $v.ref;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiSecurityRequirement other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiSecurityRequirement;
+  }
+
+  @override
+  void update(void Function(OpenApiSecurityRequirementBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiSecurityRequirement build() => _build();
+
+  _$OpenApiSecurityRequirement _build() {
+    _$OpenApiSecurityRequirement _$result;
+    try {
+      _$result = _$v ??
+          new _$OpenApiSecurityRequirement._(
+            schemes: schemes.build(),
+            ref: ref,
+            node: node,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'schemes';
+        schemes.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'OpenApiSecurityRequirement', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiComponentOrRef<T extends OpenApiComponent<T>>
+    extends OpenApiComponentOrRef<T> {
+  @override
+  final String? ref;
+  @override
+  final T? component;
+  @override
+  final OpenApiReference<T>? reference;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiComponentOrRef(
+          [void Function(OpenApiComponentOrRefBuilder<T>)? updates]) =>
+      (new OpenApiComponentOrRefBuilder<T>()..update(updates))._build();
+
+  _$OpenApiComponentOrRef._(
+      {this.ref, this.component, this.reference, this.node})
+      : super._() {
+    if (T == dynamic) {
+      throw new BuiltValueMissingGenericsError(r'OpenApiComponentOrRef', 'T');
+    }
+  }
+
+  @override
+  OpenApiComponentOrRef<T> rebuild(
+          void Function(OpenApiComponentOrRefBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiComponentOrRefBuilder<T> toBuilder() =>
+      new OpenApiComponentOrRefBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiComponentOrRef &&
+        ref == other.ref &&
+        component == other.component &&
+        reference == other.reference &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, component.hashCode);
+    _$hash = $jc(_$hash, reference.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiComponentOrRef')
+          ..add('ref', ref)
+          ..add('component', component)
+          ..add('reference', reference)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiComponentOrRefBuilder<T extends OpenApiComponent<T>>
+    implements
+        Builder<OpenApiComponentOrRef<T>, OpenApiComponentOrRefBuilder<T>> {
+  _$OpenApiComponentOrRef<T>? _$v;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  T? _component;
+  T? get component => _$this._component;
+  set component(T? component) => _$this._component = component;
+
+  OpenApiReference<T>? _reference;
+  OpenApiReference<T>? get reference => _$this._reference;
+  set reference(OpenApiReference<T>? reference) =>
+      _$this._reference = reference;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiComponentOrRefBuilder();
+
+  OpenApiComponentOrRefBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _ref = $v.ref;
+      _component = $v.component;
+      _reference = $v.reference;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiComponentOrRef<T> other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiComponentOrRef<T>;
+  }
+
+  @override
+  void update(void Function(OpenApiComponentOrRefBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiComponentOrRef<T> build() => _build();
+
+  _$OpenApiComponentOrRef<T> _build() {
+    OpenApiComponentOrRef._finalize(this);
+    final _$result = _$v ??
+        new _$OpenApiComponentOrRef<T>._(
+          ref: ref,
+          component: component,
+          reference: reference,
+          node: node,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiHeaderReference extends OpenApiHeaderReference {
+  @override
+  final String ref;
+  @override
+  final String name;
+  @override
+  final String? summary;
+  @override
+  final String? description;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiHeaderReference(
+          [void Function(OpenApiHeaderReferenceBuilder)? updates]) =>
+      (new OpenApiHeaderReferenceBuilder()..update(updates))._build();
+
+  _$OpenApiHeaderReference._(
+      {required this.ref,
+      required this.name,
+      this.summary,
+      this.description,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        ref, r'OpenApiHeaderReference', 'ref');
+    BuiltValueNullFieldError.checkNotNull(
+        name, r'OpenApiHeaderReference', 'name');
+  }
+
+  @override
+  OpenApiHeaderReference rebuild(
+          void Function(OpenApiHeaderReferenceBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiHeaderReferenceBuilder toBuilder() =>
+      new OpenApiHeaderReferenceBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiHeaderReference &&
+        ref == other.ref &&
+        name == other.name &&
+        summary == other.summary &&
+        description == other.description &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiHeaderReference')
+          ..add('ref', ref)
+          ..add('name', name)
+          ..add('summary', summary)
+          ..add('description', description)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiHeaderReferenceBuilder
+    implements Builder<OpenApiHeaderReference, OpenApiHeaderReferenceBuilder> {
+  _$OpenApiHeaderReference? _$v;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(String? summary) => _$this._summary = summary;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiHeaderReferenceBuilder();
+
+  OpenApiHeaderReferenceBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _ref = $v.ref;
+      _name = $v.name;
+      _summary = $v.summary;
+      _description = $v.description;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiHeaderReference other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiHeaderReference;
+  }
+
+  @override
+  void update(void Function(OpenApiHeaderReferenceBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiHeaderReference build() => _build();
+
+  _$OpenApiHeaderReference _build() {
+    final _$result = _$v ??
+        new _$OpenApiHeaderReference._(
+          ref: BuiltValueNullFieldError.checkNotNull(
+              ref, r'OpenApiHeaderReference', 'ref'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'OpenApiHeaderReference', 'name'),
+          summary: summary,
+          description: description,
+          node: node,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiSchemaReference extends OpenApiSchemaReference {
+  @override
+  final String ref;
+  @override
+  final String name;
+  @override
+  final String? summary;
+  @override
+  final String? description;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiSchemaReference(
+          [void Function(OpenApiSchemaReferenceBuilder)? updates]) =>
+      (new OpenApiSchemaReferenceBuilder()..update(updates))._build();
+
+  _$OpenApiSchemaReference._(
+      {required this.ref,
+      required this.name,
+      this.summary,
+      this.description,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        ref, r'OpenApiSchemaReference', 'ref');
+    BuiltValueNullFieldError.checkNotNull(
+        name, r'OpenApiSchemaReference', 'name');
+  }
+
+  @override
+  OpenApiSchemaReference rebuild(
+          void Function(OpenApiSchemaReferenceBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiSchemaReferenceBuilder toBuilder() =>
+      new OpenApiSchemaReferenceBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiSchemaReference &&
+        ref == other.ref &&
+        name == other.name &&
+        summary == other.summary &&
+        description == other.description &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiSchemaReference')
+          ..add('ref', ref)
+          ..add('name', name)
+          ..add('summary', summary)
+          ..add('description', description)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiSchemaReferenceBuilder
+    implements Builder<OpenApiSchemaReference, OpenApiSchemaReferenceBuilder> {
+  _$OpenApiSchemaReference? _$v;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(String? summary) => _$this._summary = summary;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiSchemaReferenceBuilder();
+
+  OpenApiSchemaReferenceBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _ref = $v.ref;
+      _name = $v.name;
+      _summary = $v.summary;
+      _description = $v.description;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiSchemaReference other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiSchemaReference;
+  }
+
+  @override
+  void update(void Function(OpenApiSchemaReferenceBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiSchemaReference build() => _build();
+
+  _$OpenApiSchemaReference _build() {
+    final _$result = _$v ??
+        new _$OpenApiSchemaReference._(
+          ref: BuiltValueNullFieldError.checkNotNull(
+              ref, r'OpenApiSchemaReference', 'ref'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'OpenApiSchemaReference', 'name'),
+          summary: summary,
+          description: description,
+          node: node,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiParameterReference extends OpenApiParameterReference {
+  @override
+  final String ref;
+  @override
+  final String name;
+  @override
+  final String? summary;
+  @override
+  final String? description;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiParameterReference(
+          [void Function(OpenApiParameterReferenceBuilder)? updates]) =>
+      (new OpenApiParameterReferenceBuilder()..update(updates))._build();
+
+  _$OpenApiParameterReference._(
+      {required this.ref,
+      required this.name,
+      this.summary,
+      this.description,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        ref, r'OpenApiParameterReference', 'ref');
+    BuiltValueNullFieldError.checkNotNull(
+        name, r'OpenApiParameterReference', 'name');
+  }
+
+  @override
+  OpenApiParameterReference rebuild(
+          void Function(OpenApiParameterReferenceBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiParameterReferenceBuilder toBuilder() =>
+      new OpenApiParameterReferenceBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiParameterReference &&
+        ref == other.ref &&
+        name == other.name &&
+        summary == other.summary &&
+        description == other.description &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiParameterReference')
+          ..add('ref', ref)
+          ..add('name', name)
+          ..add('summary', summary)
+          ..add('description', description)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiParameterReferenceBuilder
+    implements
+        Builder<OpenApiParameterReference, OpenApiParameterReferenceBuilder> {
+  _$OpenApiParameterReference? _$v;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(String? summary) => _$this._summary = summary;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiParameterReferenceBuilder();
+
+  OpenApiParameterReferenceBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _ref = $v.ref;
+      _name = $v.name;
+      _summary = $v.summary;
+      _description = $v.description;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiParameterReference other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiParameterReference;
+  }
+
+  @override
+  void update(void Function(OpenApiParameterReferenceBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiParameterReference build() => _build();
+
+  _$OpenApiParameterReference _build() {
+    final _$result = _$v ??
+        new _$OpenApiParameterReference._(
+          ref: BuiltValueNullFieldError.checkNotNull(
+              ref, r'OpenApiParameterReference', 'ref'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'OpenApiParameterReference', 'name'),
+          summary: summary,
+          description: description,
+          node: node,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiRequestBodyReference extends OpenApiRequestBodyReference {
+  @override
+  final String ref;
+  @override
+  final String name;
+  @override
+  final String? summary;
+  @override
+  final String? description;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiRequestBodyReference(
+          [void Function(OpenApiRequestBodyReferenceBuilder)? updates]) =>
+      (new OpenApiRequestBodyReferenceBuilder()..update(updates))._build();
+
+  _$OpenApiRequestBodyReference._(
+      {required this.ref,
+      required this.name,
+      this.summary,
+      this.description,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        ref, r'OpenApiRequestBodyReference', 'ref');
+    BuiltValueNullFieldError.checkNotNull(
+        name, r'OpenApiRequestBodyReference', 'name');
+  }
+
+  @override
+  OpenApiRequestBodyReference rebuild(
+          void Function(OpenApiRequestBodyReferenceBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiRequestBodyReferenceBuilder toBuilder() =>
+      new OpenApiRequestBodyReferenceBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiRequestBodyReference &&
+        ref == other.ref &&
+        name == other.name &&
+        summary == other.summary &&
+        description == other.description &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiRequestBodyReference')
+          ..add('ref', ref)
+          ..add('name', name)
+          ..add('summary', summary)
+          ..add('description', description)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiRequestBodyReferenceBuilder
+    implements
+        Builder<OpenApiRequestBodyReference,
+            OpenApiRequestBodyReferenceBuilder> {
+  _$OpenApiRequestBodyReference? _$v;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(String? summary) => _$this._summary = summary;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiRequestBodyReferenceBuilder();
+
+  OpenApiRequestBodyReferenceBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _ref = $v.ref;
+      _name = $v.name;
+      _summary = $v.summary;
+      _description = $v.description;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiRequestBodyReference other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiRequestBodyReference;
+  }
+
+  @override
+  void update(void Function(OpenApiRequestBodyReferenceBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiRequestBodyReference build() => _build();
+
+  _$OpenApiRequestBodyReference _build() {
+    final _$result = _$v ??
+        new _$OpenApiRequestBodyReference._(
+          ref: BuiltValueNullFieldError.checkNotNull(
+              ref, r'OpenApiRequestBodyReference', 'ref'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'OpenApiRequestBodyReference', 'name'),
+          summary: summary,
+          description: description,
+          node: node,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiResponseReference extends OpenApiResponseReference {
+  @override
+  final String ref;
+  @override
+  final String name;
+  @override
+  final String? summary;
+  @override
+  final String? description;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiResponseReference(
+          [void Function(OpenApiResponseReferenceBuilder)? updates]) =>
+      (new OpenApiResponseReferenceBuilder()..update(updates))._build();
+
+  _$OpenApiResponseReference._(
+      {required this.ref,
+      required this.name,
+      this.summary,
+      this.description,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        ref, r'OpenApiResponseReference', 'ref');
+    BuiltValueNullFieldError.checkNotNull(
+        name, r'OpenApiResponseReference', 'name');
+  }
+
+  @override
+  OpenApiResponseReference rebuild(
+          void Function(OpenApiResponseReferenceBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiResponseReferenceBuilder toBuilder() =>
+      new OpenApiResponseReferenceBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiResponseReference &&
+        ref == other.ref &&
+        name == other.name &&
+        summary == other.summary &&
+        description == other.description &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiResponseReference')
+          ..add('ref', ref)
+          ..add('name', name)
+          ..add('summary', summary)
+          ..add('description', description)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiResponseReferenceBuilder
+    implements
+        Builder<OpenApiResponseReference, OpenApiResponseReferenceBuilder> {
+  _$OpenApiResponseReference? _$v;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(String? summary) => _$this._summary = summary;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiResponseReferenceBuilder();
+
+  OpenApiResponseReferenceBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _ref = $v.ref;
+      _name = $v.name;
+      _summary = $v.summary;
+      _description = $v.description;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiResponseReference other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiResponseReference;
+  }
+
+  @override
+  void update(void Function(OpenApiResponseReferenceBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiResponseReference build() => _build();
+
+  _$OpenApiResponseReference _build() {
+    final _$result = _$v ??
+        new _$OpenApiResponseReference._(
+          ref: BuiltValueNullFieldError.checkNotNull(
+              ref, r'OpenApiResponseReference', 'ref'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'OpenApiResponseReference', 'name'),
+          summary: summary,
+          description: description,
+          node: node,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OpenApiPathItemReference extends OpenApiPathItemReference {
+  @override
+  final String ref;
+  @override
+  final String name;
+  @override
+  final String? summary;
+  @override
+  final String? description;
+  @override
+  final YamlNode? node;
+
+  factory _$OpenApiPathItemReference(
+          [void Function(OpenApiPathItemReferenceBuilder)? updates]) =>
+      (new OpenApiPathItemReferenceBuilder()..update(updates))._build();
+
+  _$OpenApiPathItemReference._(
+      {required this.ref,
+      required this.name,
+      this.summary,
+      this.description,
+      this.node})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        ref, r'OpenApiPathItemReference', 'ref');
+    BuiltValueNullFieldError.checkNotNull(
+        name, r'OpenApiPathItemReference', 'name');
+  }
+
+  @override
+  OpenApiPathItemReference rebuild(
+          void Function(OpenApiPathItemReferenceBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenApiPathItemReferenceBuilder toBuilder() =>
+      new OpenApiPathItemReferenceBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenApiPathItemReference &&
+        ref == other.ref &&
+        name == other.name &&
+        summary == other.summary &&
+        description == other.description &&
+        node == other.node;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, ref.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, summary.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenApiPathItemReference')
+          ..add('ref', ref)
+          ..add('name', name)
+          ..add('summary', summary)
+          ..add('description', description)
+          ..add('node', node))
+        .toString();
+  }
+}
+
+class OpenApiPathItemReferenceBuilder
+    implements
+        Builder<OpenApiPathItemReference, OpenApiPathItemReferenceBuilder> {
+  _$OpenApiPathItemReference? _$v;
+
+  String? _ref;
+  String? get ref => _$this._ref;
+  set ref(String? ref) => _$this._ref = ref;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _summary;
+  String? get summary => _$this._summary;
+  set summary(String? summary) => _$this._summary = summary;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  YamlNode? _node;
+  YamlNode? get node => _$this._node;
+  set node(YamlNode? node) => _$this._node = node;
+
+  OpenApiPathItemReferenceBuilder();
+
+  OpenApiPathItemReferenceBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _ref = $v.ref;
+      _name = $v.name;
+      _summary = $v.summary;
+      _description = $v.description;
+      _node = $v.node;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OpenApiPathItemReference other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenApiPathItemReference;
+  }
+
+  @override
+  void update(void Function(OpenApiPathItemReferenceBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenApiPathItemReference build() => _build();
+
+  _$OpenApiPathItemReference _build() {
+    final _$result = _$v ??
+        new _$OpenApiPathItemReference._(
+          ref: BuiltValueNullFieldError.checkNotNull(
+              ref, r'OpenApiPathItemReference', 'ref'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'OpenApiPathItemReference', 'name'),
+          summary: summary,
+          description: description,
+          node: node,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/cli/lib/src/openapi/ast/openapi_reference.dart
+++ b/apps/cli/lib/src/openapi/ast/openapi_reference.dart
@@ -1,0 +1,444 @@
+part of 'openapi_ast.dart';
+
+abstract class OpenApiComponentOrRef<T extends OpenApiComponent<T>>
+    implements
+        Built<OpenApiComponentOrRef<T>, OpenApiComponentOrRefBuilder<T>>,
+        OpenApiNode {
+  factory OpenApiComponentOrRef.component({
+    required T component,
+    String? ref,
+  }) {
+    return _$OpenApiComponentOrRef<T>._(
+      ref: ref,
+      component: component,
+    );
+  }
+
+  factory OpenApiComponentOrRef.reference({
+    required OpenApiReference<T> reference,
+    String? ref,
+    YamlNode? node,
+  }) {
+    return _$OpenApiComponentOrRef<T>._(
+      ref: ref,
+      node: node,
+      reference: reference,
+    );
+  }
+
+  factory OpenApiComponentOrRef.build([
+    void Function(OpenApiComponentOrRefBuilder<T>) updates,
+  ]) = _$OpenApiComponentOrRef<T>;
+
+  OpenApiComponentOrRef._();
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void
+      _finalize<T extends OpenApiComponent<T>, R extends OpenApiReference<T>>(
+    OpenApiComponentOrRefBuilder<T> builder,
+  ) {
+    final setNeither = builder.component == null && builder.reference == null;
+    final setBoth = builder.component != null && builder.reference != null;
+    if (setNeither || setBoth) {
+      throw ArgumentError(
+        'Exactly one of component or reference must be set',
+      );
+    }
+  }
+
+  @override
+  String? get ref;
+
+  T? get component;
+  OpenApiReference<T>? get reference;
+
+  T resolve(OpenApiComponents components) {
+    if (component case final component?) {
+      return component;
+    }
+    final reference = this.reference!;
+    return reference.resolve(components).rebuild(
+      (b) {
+        if (reference.summary case final summary) {
+          b.summary = summary;
+        }
+        if (reference.description case final description) {
+          b.description = description;
+        }
+      },
+    );
+  }
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) {
+    if (component case final component?) {
+      return component.accept(visitor);
+    }
+    return reference!.accept(visitor);
+  }
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) {
+    if (component case final component?) {
+      return component.acceptWithArg(visitor, arg);
+    }
+    return reference!.acceptWithArg(visitor, arg);
+  }
+}
+
+sealed class OpenApiReference<T extends OpenApiComponent<T>>
+    implements OpenApiNode {
+  /// The reference identifier.
+  ///
+  /// This MUST be in the form of a URI.
+  @override
+  String get ref;
+  String get name;
+
+  /// A short summary which by default SHOULD override that of the referenced
+  /// component.
+  ///
+  /// If the referenced object-type does not allow a summary field, then this
+  /// field has no effect.
+  String? get summary;
+
+  /// A description which by default SHOULD override that of the referenced
+  /// component.
+  ///
+  /// CommonMark syntax MAY be used for rich text representation. If the
+  /// referenced object-type does not allow a description field, then this
+  /// field has no effect.
+  String? get description;
+
+  T resolve(OpenApiComponents components);
+}
+
+abstract class OpenApiHeaderReference
+    implements
+        Built<OpenApiHeaderReference, OpenApiHeaderReferenceBuilder>,
+        OpenApiReference<OpenApiHeader> {
+  factory OpenApiHeaderReference({
+    required String ref,
+    required String name,
+    String? summary,
+    String? description,
+    YamlNode? node,
+  }) {
+    return _$OpenApiHeaderReference._(
+      ref: ref,
+      name: name,
+      summary: summary,
+      description: description,
+      node: node,
+    );
+  }
+
+  factory OpenApiHeaderReference.build([
+    void Function(OpenApiHeaderReferenceBuilder) updates,
+  ]) = _$OpenApiHeaderReference;
+
+  OpenApiHeaderReference._();
+
+  @override
+  OpenApiHeader resolve(OpenApiComponents components) {
+    return components.headers[name]!;
+  }
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitReference(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) {
+    return visitor.visitReference(this, arg);
+  }
+}
+
+abstract class OpenApiSchemaReference
+    implements
+        Built<OpenApiSchemaReference, OpenApiSchemaReferenceBuilder>,
+        OpenApiReference<OpenApiSchema> {
+  factory OpenApiSchemaReference({
+    required String ref,
+    required String name,
+    String? summary,
+    String? description,
+    YamlNode? node,
+  }) {
+    return _$OpenApiSchemaReference._(
+      ref: ref,
+      name: name,
+      summary: summary,
+      description: description,
+      node: node,
+    );
+  }
+
+  factory OpenApiSchemaReference.build([
+    void Function(OpenApiSchemaReferenceBuilder) updates,
+  ]) = _$OpenApiSchemaReference;
+
+  OpenApiSchemaReference._();
+
+  @override
+  OpenApiSchema resolve(OpenApiComponents components) {
+    return components.schemas[name]!;
+  }
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitReference(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) {
+    return visitor.visitReference(this, arg);
+  }
+}
+
+abstract class OpenApiParameterReference
+    implements
+        Built<OpenApiParameterReference, OpenApiParameterReferenceBuilder>,
+        OpenApiReference<OpenApiParameter> {
+  factory OpenApiParameterReference({
+    required String ref,
+    required String name,
+    String? summary,
+    String? description,
+    YamlNode? node,
+  }) {
+    return _$OpenApiParameterReference._(
+      ref: ref,
+      name: name,
+      summary: summary,
+      description: description,
+      node: node,
+    );
+  }
+
+  factory OpenApiParameterReference.build([
+    void Function(OpenApiParameterReferenceBuilder) updates,
+  ]) = _$OpenApiParameterReference;
+
+  OpenApiParameterReference._();
+
+  @override
+  OpenApiParameter resolve(OpenApiComponents components) {
+    return components.parameters[name]!;
+  }
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitReference(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) {
+    return visitor.visitReference(this, arg);
+  }
+}
+
+abstract class OpenApiRequestBodyReference
+    implements
+        Built<OpenApiRequestBodyReference, OpenApiRequestBodyReferenceBuilder>,
+        OpenApiReference<OpenApiRequestBody> {
+  factory OpenApiRequestBodyReference({
+    required String ref,
+    required String name,
+    String? summary,
+    String? description,
+    YamlNode? node,
+  }) {
+    return _$OpenApiRequestBodyReference._(
+      ref: ref,
+      name: name,
+      summary: summary,
+      description: description,
+      node: node,
+    );
+  }
+
+  factory OpenApiRequestBodyReference.build([
+    void Function(OpenApiRequestBodyReferenceBuilder) updates,
+  ]) = _$OpenApiRequestBodyReference;
+
+  OpenApiRequestBodyReference._();
+
+  @override
+  OpenApiRequestBody resolve(OpenApiComponents components) {
+    return components.requestBodies[name]!;
+  }
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitReference(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) {
+    return visitor.visitReference(this, arg);
+  }
+}
+
+abstract class OpenApiResponseReference
+    implements
+        Built<OpenApiResponseReference, OpenApiResponseReferenceBuilder>,
+        OpenApiReference<OpenApiResponse> {
+  factory OpenApiResponseReference({
+    required String ref,
+    required String name,
+    String? summary,
+    String? description,
+    YamlNode? node,
+  }) {
+    return _$OpenApiResponseReference._(
+      ref: ref,
+      name: name,
+      summary: summary,
+      description: description,
+      node: node,
+    );
+  }
+
+  factory OpenApiResponseReference.build([
+    void Function(OpenApiResponseReferenceBuilder) updates,
+  ]) = _$OpenApiResponseReference;
+
+  OpenApiResponseReference._();
+
+  @override
+  OpenApiResponse resolve(OpenApiComponents components) {
+    return components.responses[name]!;
+  }
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitReference(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) {
+    return visitor.visitReference(this, arg);
+  }
+}
+
+abstract class OpenApiPathItemReference
+    implements
+        Built<OpenApiPathItemReference, OpenApiPathItemReferenceBuilder>,
+        OpenApiReference<OpenApiPathItem> {
+  factory OpenApiPathItemReference({
+    required String ref,
+    required String name,
+    String? summary,
+    String? description,
+    YamlNode? node,
+  }) {
+    return _$OpenApiPathItemReference._(
+      ref: ref,
+      name: name,
+      summary: summary,
+      description: description,
+      node: node,
+    );
+  }
+
+  factory OpenApiPathItemReference.build([
+    void Function(OpenApiPathItemReferenceBuilder) updates,
+  ]) = _$OpenApiPathItemReference;
+
+  OpenApiPathItemReference._();
+
+  @override
+  OpenApiPathItem resolve(OpenApiComponents components) {
+    return components.paths[name]!;
+  }
+
+  @override
+  R accept<R>(OpenApiVisitor<R> visitor) => visitor.visitReference(this);
+
+  @override
+  R acceptWithArg<R, A>(OpenApiVisitorWithArg<R, A> visitor, A arg) {
+    return visitor.visitReference(this, arg);
+  }
+}
+
+// abstract class OpenApiSecuritySchemeReference
+//     implements
+//         Built<OpenApiSecuritySchemeReference, OpenApiSecuritySchemeReferenceBuilder>,
+//         OpenApiReference<OpenApiSecurityScheme> {
+//   factory OpenApiSecuritySchemeReference({
+//     required String ref,
+//     required String name,
+//     String? summary,
+//     String? description,
+//   }) {
+//     return _$OpenApiSecuritySchemeReference._(
+//       ref: ref,
+//       name: name,
+//       summary: summary,
+//       description: description,
+//     );
+//   }
+
+//   factory OpenApiSecuritySchemeReference.build([
+//     void Function(OpenApiSecuritySchemeReferenceBuilder) updates,
+//   ]) = _$OpenApiSecuritySchemeReference;
+
+//   OpenApiSecuritySchemeReference._();
+
+//   @override
+//   OpenApiSecurityScheme resolve(OpenApiComponents components) {
+//     return components.securitySchemes[name];
+//   }
+// }
+
+// abstract class OpenApiLinkReference
+//     implements
+//         Built<OpenApiLinkReference, OpenApiLinkReferenceBuilder>,
+//         OpenApiReference<OpenApiLink> {
+//   factory OpenApiLinkReference({
+//     required String ref,
+//     required String name,
+//     String? summary,
+//     String? description,
+//   }) {
+//     return _$OpenApiLinkReference._(
+//       ref: ref,
+//       name: name,
+//       summary: summary,
+//       description: description,
+//     );
+//   }
+
+//   factory OpenApiLinkReference.build([
+//     void Function(OpenApiLinkReferenceBuilder) updates,
+//   ]) = _$OpenApiLinkReference;
+
+//   OpenApiLinkReference._();
+
+//   @override
+//   OpenApiLink resolve(OpenApiComponents components) {
+//     return components.links[name];
+//   }
+// }
+
+// abstract class OpenApiCallbackReference
+//     implements
+//         Built<OpenApiCallbackReference, OpenApiCallbackReferenceBuilder>,
+//         OpenApiReference<OpenApiCallback> {
+//   factory OpenApiCallbackReference({
+//     required String ref,
+//     required String name,
+//     String? summary,
+//     String? description,
+//   }) {
+//     return _$OpenApiCallbackReference._(
+//       ref: ref,
+//       name: name,
+//       summary: summary,
+//       description: description,
+//     );
+//   }
+
+//   factory OpenApiCallbackReference.build([
+//     void Function(OpenApiCallbackReferenceBuilder) updates,
+//   ]) = _$OpenApiCallbackReference;
+
+//   OpenApiCallbackReference._();
+
+//   @override
+//   OpenApiCallback resolve(OpenApiComponents components) {
+//     return components.callbacks[name];
+//   }
+// }

--- a/apps/cli/lib/src/openapi/ast/openapi_visitor.dart
+++ b/apps/cli/lib/src/openapi/ast/openapi_visitor.dart
@@ -1,0 +1,73 @@
+import 'package:celest_cli/src/openapi/ast/openapi_ast.dart';
+
+abstract class OpenApiVisitor<R> {
+  R visitDocument(OpenApiDocument document);
+  R visitInfo(OpenApiInfo info);
+  R visitServer(OpenApiServer server);
+  R visitServerVariable(OpenApiServerVariable serverVariable);
+  R visitPathItem(OpenApiPathItem pathItem);
+  R visitOperation(OpenApiOperation operation);
+  R visitParameter(OpenApiParameter parameter);
+  R visitMediaType(OpenApiMediaType mediaType);
+  R visitRequestBody(OpenApiRequestBody requestBody);
+  R visitEncoding(OpenApiEncoding encoding);
+  R visitResponse(OpenApiResponse response);
+  R visitHeader(OpenApiHeader header);
+  R visitComponents(OpenApiComponents components);
+  R visitComponent(OpenApiComponent component) => switch (component) {
+        OpenApiPathItem() => visitPathItem(component),
+        OpenApiParameter() => visitParameter(component),
+        OpenApiRequestBody() => visitRequestBody(component),
+        OpenApiResponse() => visitResponse(component),
+        OpenApiHeader() => visitHeader(component),
+        OpenApiSchema() => visitSchema(component),
+        OpenApiSecurityScheme() => visitSecurityScheme(component),
+      };
+  R visitSchema(OpenApiSchema schema);
+  R visitSecurityRequirement(OpenApiSecurityRequirement securityRequirement);
+  R visitSecurityScheme(OpenApiSecurityScheme securityScheme);
+  R visitOAuthFlows(OpenApiOAuthFlows oauthFlows);
+  R visitOAuthFlow(OpenApiOAuthFlow oauthFlow);
+  R visitAdditionalProperties(OpenApiAdditionalProperties additionalProperties);
+  R visitDiscriminator(OpenApiDiscriminator discriminator);
+  R visitReference(OpenApiReference reference);
+}
+
+abstract class OpenApiVisitorWithArg<R, A> {
+  R visitDocument(OpenApiDocument document, A arg);
+  R visitInfo(OpenApiInfo info, A arg);
+  R visitServer(OpenApiServer server, A arg);
+  R visitServerVariable(OpenApiServerVariable serverVariable, A arg);
+  R visitPathItem(OpenApiPathItem pathItem, A arg);
+  R visitOperation(OpenApiOperation operation, A arg);
+  R visitParameter(OpenApiParameter parameter, A arg);
+  R visitMediaType(OpenApiMediaType mediaType, A arg);
+  R visitRequestBody(OpenApiRequestBody requestBody, A arg);
+  R visitEncoding(OpenApiEncoding encoding, A arg);
+  R visitResponse(OpenApiResponse response, A arg);
+  R visitHeader(OpenApiHeader header, A arg);
+  R visitComponents(OpenApiComponents components, A arg);
+  R visitComponent(OpenApiComponent component, A arg) => switch (component) {
+        OpenApiPathItem() => visitPathItem(component, arg),
+        OpenApiParameter() => visitParameter(component, arg),
+        OpenApiRequestBody() => visitRequestBody(component, arg),
+        OpenApiResponse() => visitResponse(component, arg),
+        OpenApiHeader() => visitHeader(component, arg),
+        OpenApiSchema() => visitSchema(component, arg),
+        OpenApiSecurityScheme() => visitSecurityScheme(component, arg),
+      };
+  R visitSchema(OpenApiSchema schema, A arg);
+  R visitSecurityRequirement(
+    OpenApiSecurityRequirement securityRequirement,
+    A arg,
+  );
+  R visitSecurityScheme(OpenApiSecurityScheme securityScheme, A arg);
+  R visitOAuthFlows(OpenApiOAuthFlows oauthFlows, A arg);
+  R visitOAuthFlow(OpenApiOAuthFlow oauthFlow, A arg);
+  R visitAdditionalProperties(
+    OpenApiAdditionalProperties additionalProperties,
+    A arg,
+  );
+  R visitDiscriminator(OpenApiDiscriminator discriminator, A arg);
+  R visitReference(OpenApiReference reference, A arg);
+}

--- a/apps/cli/lib/src/openapi/loader/openapi_loader.dart
+++ b/apps/cli/lib/src/openapi/loader/openapi_loader.dart
@@ -1,0 +1,60 @@
+import 'package:celest_cli/src/openapi/ast/openapi_ast.dart';
+import 'package:celest_cli/src/openapi/loader/openapi_v3_loader.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart';
+
+final _versionPattern = RegExp(r'^(\d)\.(\d)(?:\.(\d))?$');
+
+final class OpenApiDocumentLoader {
+  OpenApiDocumentLoader();
+
+  OpenApiDocument load({
+    required String jsonOrYaml,
+    required Uri sourceUri,
+  }) {
+    return loadOpenApiDocument(
+      jsonOrYaml,
+      sourceUri: sourceUri,
+    );
+  }
+}
+
+OpenApiDocument loadOpenApiDocument(
+  String jsonOrYaml, {
+  required Uri sourceUri,
+}) {
+  final document = loadYamlDocument(jsonOrYaml, sourceUrl: sourceUri);
+  final root = document.contents as YamlMap;
+
+  final version = (root.nodes['swagger'] ?? root.nodes['openapi'])?.value;
+  if (version == null || version is! String) {
+    throw Exception('Could not detect OpenAPI version');
+  }
+
+  final semverMatch = _versionPattern.firstMatch(version);
+  final majorVersion = switch (semverMatch?.group(1)) {
+    final match? => int.tryParse(match),
+    null => null,
+  };
+  final minorVersion = switch (semverMatch?.group(2)) {
+    final match? => int.tryParse(match),
+    null => 0,
+  };
+  final patchVersion = switch (semverMatch?.group(3)) {
+    final match? => int.tryParse(match),
+    null => 0,
+  };
+  if (majorVersion == null || minorVersion == null || patchVersion == null) {
+    throw Exception('Invalid OpenAPI version string: $version');
+  }
+  final semver = Version(
+    majorVersion,
+    minorVersion,
+    patchVersion,
+  );
+  return switch (majorVersion) {
+    3 => OpenApiV3Loader(version: semver, rootNode: root).load(),
+    2 => throw Exception('OpenAPI 2.0 is not supported'),
+    _ => throw Exception('Unknown OpenAPI version: $version'),
+  };
+}

--- a/apps/cli/lib/src/openapi/loader/openapi_v3_loader.dart
+++ b/apps/cli/lib/src/openapi/loader/openapi_v3_loader.dart
@@ -1,0 +1,1445 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:celest_cli/src/openapi/ast/openapi_ast.dart';
+import 'package:celest_cli/src/openapi/type/json_type.dart';
+import 'package:celest_cli/src/openapi/type/json_type_format.spec.dart';
+import 'package:collection/collection.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart';
+
+final class OpenApiV3Loader {
+  OpenApiV3Loader({
+    required this.version,
+    required this.rootNode,
+  }) : _document = OpenApiDocumentBuilder()
+          ..version = version; // TODO(dnys1): Source
+
+  static final _extensionPattern = RegExp('^x-');
+  static final _pathPattern = RegExp(r'^/');
+  static final _statusCodePattern = RegExp(r'^[1-5][\dX]{2}$');
+  static final _mediaTypePattern = RegExp(r'^[a-z]+/[a-z0-9\.\-\+]+$');
+
+  final OpenApiDocumentBuilder _document;
+
+  late final OpenApiComponentsBuilder _components = _document.components;
+  late final OpenApiComponents components = _components.build();
+
+  final Version version;
+  final YamlMap rootNode;
+
+  OpenApiDocument load() {
+    rootNode.checkRequiredFields(['openapi', 'info', 'paths']);
+    rootNode.checkAllowedFields([
+      'components',
+      'externalDocs',
+      'info',
+      'openapi',
+      'paths',
+      'security',
+      'servers',
+      'tags',
+      _extensionPattern,
+    ]);
+
+    _document
+      ..ref = '#'
+      ..node = rootNode;
+
+    _loadInfo();
+    _loadServers();
+    _loadComponents();
+    _loadPaths();
+    _loadSecurityRequirements();
+
+    return _document.build();
+  }
+
+  OpenApiReference<T>
+      _ref<T extends OpenApiComponent<T>, R extends OpenApiReference<T>>(
+    YamlMap refNode,
+  ) {
+    final map = Map.fromEntries(refNode.yamlNodes);
+    final ref = map[r'$ref']?.getScalar<String>();
+    if (ref == null) {
+      throw Exception('OpenAPI component reference is missing "$refNode"');
+    }
+    final summary = map['summary']?.getScalar<String>();
+    final description = map['description']?.getScalar<String>();
+    switch (ref.split('/')) {
+      case ['#', 'components', final type, final name]:
+        return switch (type) {
+          'schemas' => OpenApiSchemaReference(
+              ref: ref,
+              name: name,
+              summary: summary,
+              description: description,
+              node: refNode,
+            ),
+          'responses' => OpenApiResponseReference(
+              ref: ref,
+              name: name,
+              summary: summary,
+              description: description,
+              node: refNode,
+            ),
+          'parameters' => OpenApiParameterReference(
+              ref: ref,
+              name: name,
+              summary: summary,
+              description: description,
+              node: refNode,
+            ),
+          'requestBodies' => OpenApiRequestBodyReference(
+              ref: ref,
+              name: name,
+              summary: summary,
+              description: description,
+              node: refNode,
+            ),
+          'headers' => OpenApiHeaderReference(
+              ref: ref,
+              name: name,
+              summary: summary,
+              description: description,
+              node: refNode,
+            ),
+          _ => throw Exception('Invalid component type: $type'),
+        } as R;
+      default:
+        throw Exception('Invalid component reference: $refNode');
+    }
+  }
+
+  void _loadInfo() {
+    final infoNode = rootNode.nodes['info'].getAs<YamlMap>();
+    if (infoNode == null) {
+      throw Exception('OpenAPI document is missing required key "info"');
+    }
+
+    infoNode.checkRequiredFields(['title', 'version']);
+    infoNode.checkAllowedFields([
+      'contact',
+      'description',
+      'license',
+      'summary',
+      'termsOfService',
+      'title',
+      'version',
+      _extensionPattern,
+    ]);
+
+    _document.info
+      ..title = infoNode.nodes['title']?.value as String?
+      ..description = infoNode.nodes['description']?.value as String?
+      ..apiVersion = infoNode.nodes['version']?.value as String?
+      ..ref = '#/info'
+      ..node = infoNode;
+  }
+
+  void _loadServers() {
+    final serversNode = rootNode.nodes['servers'].getAs<YamlList>();
+    if (serversNode == null) {
+      return;
+    }
+
+    for (final serverNode in serversNode.nodes) {
+      if (serverNode is! YamlMap) {
+        throw Exception('OpenAPI server is not a map');
+      }
+
+      final server = _loadServer(
+        serverNode,
+        ref: '#/servers/${_document.servers.length}',
+      );
+      _document.servers.add(server.build());
+    }
+  }
+
+  void _loadPaths() {
+    final pathsNode = rootNode.nodes['paths'].getAs<YamlMap>();
+    if (pathsNode == null) {
+      throw Exception('OpenAPI document is missing required key "paths"');
+    }
+
+    pathsNode.checkAllowedFields([
+      _pathPattern,
+      _extensionPattern,
+    ]);
+
+    for (final entry in pathsNode.yamlNodes) {
+      final pathNode = entry.value.getAs<YamlMap>();
+      if (pathNode == null) {
+        throw Exception('OpenAPI path is not a map');
+      }
+
+      final path = _loadPathItemOrRef(pathNode, ref: '#/paths/${entry.key}');
+      _document.paths[entry.key] = path;
+    }
+  }
+
+  void _loadComponents() {
+    // Only load schemas, responses, parameters, requestBodies, headers, and paths
+    final componentsNode = rootNode.nodes['components'].getAs<YamlMap>();
+    if (componentsNode == null) {
+      return;
+    }
+
+    componentsNode.checkAllowedFields([
+      'schemas',
+      'responses',
+      'parameters',
+      'examples',
+      'requestBodies',
+      'headers',
+      'securitySchemes',
+      'links',
+      'callbacks',
+      'pathItems',
+      _extensionPattern,
+    ]);
+
+    _components
+      ..ref = '#/components'
+      ..node = componentsNode;
+
+    final schemasNode = componentsNode.nodes['schemas']?.getAs<YamlMap>();
+    if (schemasNode != null) {
+      for (final entry in schemasNode.yamlNodes) {
+        final schemaNode = entry.value.getAs<YamlMap>();
+        if (schemaNode == null) {
+          throw Exception('OpenAPI schema is not a map');
+        }
+        final schemaName = entry.key;
+        final schema = _loadSchema(
+          schemaNode,
+          ref: '#/components/schemas/$schemaName',
+        );
+        _components.schemas[schemaName] = schema;
+      }
+    }
+
+    final responsesNode = componentsNode.nodes['responses']?.getAs<YamlMap>();
+    if (responsesNode != null) {
+      for (final entry in responsesNode.yamlNodes) {
+        final responseNode = entry.value.getAs<YamlMap>();
+        if (responseNode == null) {
+          throw Exception('OpenAPI response is not a map');
+        }
+
+        final responseName = entry.key;
+        final response = _loadResponse(
+          responseNode,
+          ref: '#/components/responses/$responseName',
+        );
+        _components.responses[responseName] = response;
+      }
+    }
+
+    final parametersNode = componentsNode.nodes['parameters']?.getAs<YamlMap>();
+    if (parametersNode != null) {
+      for (final entry in parametersNode.yamlNodes) {
+        final parameterNode = entry.value.getAs<YamlMap>();
+        if (parameterNode == null) {
+          throw Exception('OpenAPI parameter is not a map');
+        }
+
+        final parameterName = entry.key;
+        final parameter = _loadParameter(
+          parameterNode,
+          ref: '#/components/parameters/$parameterName',
+        );
+        _components.parameters[parameterName] = parameter;
+      }
+    }
+
+    final requestBodiesNode =
+        componentsNode.nodes['requestBodies']?.getAs<YamlMap>();
+    if (requestBodiesNode != null) {
+      for (final entry in requestBodiesNode.yamlNodes) {
+        final requestBodyNode = entry.value.getAs<YamlMap>();
+        if (requestBodyNode == null) {
+          throw Exception('OpenAPI request body is not a map');
+        }
+
+        final requestBodyName = entry.key;
+        final requestBody = _loadRequestBody(
+          requestBodyNode,
+          ref: '#/components/requestBodies/$requestBodyName',
+        );
+        _components.requestBodies[requestBodyName] = requestBody;
+      }
+    }
+
+    final headersNode = componentsNode.nodes['headers']?.getAs<YamlMap>();
+    if (headersNode != null) {
+      for (final entry in headersNode.yamlNodes) {
+        final headerNode = entry.value.getAs<YamlMap>();
+        if (headerNode == null) {
+          throw Exception('OpenAPI header is not a map');
+        }
+
+        final headerName = entry.key;
+        final header = _loadHeader(
+          headerNode,
+          ref: '#/components/headers/$headerName',
+        );
+        _components.headers[headerName] = header;
+      }
+    }
+
+    final pathsNode = componentsNode.nodes['paths']?.getAs<YamlMap>();
+    if (pathsNode != null) {
+      for (final entry in pathsNode.yamlNodes) {
+        final pathNode = entry.value.getAs<YamlMap>();
+        if (pathNode == null) {
+          throw Exception('OpenAPI path is not a map');
+        }
+
+        final pathName = entry.key;
+        final path = _loadPathItem(
+          pathNode,
+          ref: '#/components/paths/$pathName',
+        );
+        _components.paths[pathName] = path;
+      }
+    }
+
+    final securitySchemesNode =
+        componentsNode.nodes['securitySchemes']?.getAs<YamlMap>();
+    if (securitySchemesNode != null) {
+      for (final entry in securitySchemesNode.yamlNodes) {
+        final securitySchemeNode = entry.value.getAs<YamlMap>();
+        if (securitySchemeNode == null) {
+          throw Exception('OpenAPI security scheme is not a map');
+        }
+
+        final securitySchemeName = entry.key;
+        final securityScheme = _loadSecurityScheme(
+          securitySchemeNode,
+          ref: '#/components/securitySchemes/$securitySchemeName',
+        );
+        _components.securitySchemes[securitySchemeName] = securityScheme;
+      }
+    }
+  }
+
+  void _loadSecurityRequirements() {
+    final securityRequirementsNode =
+        rootNode.nodes['security'].getAs<YamlList>();
+    if (securityRequirementsNode == null) {
+      return;
+    }
+
+    for (final (index, entry) in securityRequirementsNode.nodes.indexed) {
+      final requirementNode = entry.getAs<YamlMap>();
+      if (requirementNode == null) {
+        throw Exception('OpenAPI security requirement is not a map');
+      }
+
+      final requirement = OpenApiSecurityRequirementBuilder()
+        ..ref = '#/security/$index'
+        ..node = entry;
+
+      for (final entry in requirementNode.yamlNodes) {
+        requirement.schemes[entry.key] = entry.value
+            .getAs<YamlList>()!
+            .nodes
+            .map((node) => node.getScalar<String>())
+            .toBuiltList();
+      }
+
+      _document.securityRequirements.add(requirement.build());
+    }
+  }
+
+  OpenApiServerBuilder _loadServer(
+    YamlMap serverNode, {
+    required String ref,
+  }) {
+    serverNode.checkRequiredFields(['url']);
+    serverNode.checkAllowedFields([
+      'description',
+      'url',
+      'variables',
+      _extensionPattern,
+    ]);
+
+    final server = OpenApiServerBuilder()
+      ..ref = ref
+      ..node = serverNode;
+    server.url = serverNode.nodes['url']?.value as String?;
+    server.description = serverNode.nodes['description']?.value as String?;
+
+    final variablesNode = serverNode.nodes['variables'];
+    if (variablesNode != null && variablesNode is YamlMap) {
+      for (final entry in variablesNode.yamlNodes) {
+        final variableNode = entry.value;
+        if (variableNode is! YamlMap) {
+          throw Exception('OpenAPI server variable is not a map');
+        }
+
+        variableNode.checkRequiredFields(['default']);
+        variableNode.checkAllowedFields([
+          'default',
+          'description',
+          'enum',
+          'x-example',
+          _extensionPattern,
+        ]);
+
+        final variable = OpenApiServerVariableBuilder();
+        variable
+          ..defaultValue = variableNode.nodes['default']?.value as String?
+          ..description = variableNode.nodes['description']?.value as String?;
+
+        final enumNode = variableNode.nodes['enum'].getAs<YamlList>();
+        if (enumNode != null) {
+          // The array MUST NOT be empty.
+          if (enumNode.isEmpty) {
+            throw Exception('OpenAPI server variable enum is empty');
+          }
+          for (final enumValueNode in enumNode.nodes) {
+            if (enumValueNode is! YamlScalar) {
+              throw Exception(
+                'OpenAPI server variable enum value is not a scalar',
+              );
+            }
+            variable.enumValues.add(enumValueNode.value as String);
+          }
+        }
+
+        server.variables[entry.key] = variable.build();
+      }
+    }
+
+    return server;
+  }
+
+  OpenApiComponentOrRef<OpenApiPathItem> _loadPathItemOrRef(
+    YamlMap pathItemNode, {
+    required String ref,
+  }) {
+    if (pathItemNode.nodes.containsKey(r'$ref')) {
+      return OpenApiComponentOrRef.reference(
+        ref: ref,
+        node: pathItemNode,
+        reference:
+            _ref<OpenApiPathItem, OpenApiPathItemReference>(pathItemNode),
+      );
+    }
+    return OpenApiComponentOrRef.component(
+      ref: ref,
+      component: _loadPathItem(
+        pathItemNode,
+        ref: ref,
+      ),
+    );
+  }
+
+  OpenApiPathItem _loadPathItem(
+    YamlMap pathItemNode, {
+    required String ref,
+  }) {
+    if (pathItemNode.nodes.containsKey(r'$ref')) {
+      throw Exception('OpenAPI path reference is not allowed');
+    }
+
+    pathItemNode.checkAllowedFields([
+      'delete',
+      'get',
+      'head',
+      'options',
+      'parameters',
+      'patch',
+      'post',
+      'put',
+      'summary',
+      _extensionPattern,
+    ]);
+
+    final path = OpenApiPathItemBuilder();
+    path
+      ..ref = ref
+      ..node = pathItemNode
+      ..summary = pathItemNode.nodes['summary']?.value as String?;
+
+    for (final method in OpenApiOperationType.values) {
+      final operationNode = pathItemNode.nodes[method.name].getAs<YamlMap>();
+      if (operationNode == null) {
+        continue;
+      }
+
+      operationNode.checkAllowedFields([
+        'callbacks',
+        'deprecated',
+        'description',
+        'externalDocs',
+        'operationId',
+        'parameters',
+        'requestBody',
+        'responses',
+        'security',
+        'servers',
+        'summary',
+        'tags',
+        _extensionPattern,
+      ]);
+
+      final operation = OpenApiOperationBuilder()
+        ..type = method
+        ..deprecated = operationNode.nodes['deprecated']?.value as bool?
+        ..description = operationNode.nodes['description']?.value as String?
+        ..operationId = operationNode.nodes['operationId']?.value as String?
+        ..summary = operationNode.nodes['summary']?.value as String?;
+
+      final requestBodyNode =
+          operationNode.nodes['requestBody']?.getAs<YamlMap>();
+      if (requestBodyNode != null) {
+        final requestBody = _loadRequestBodyOrRef(
+          requestBodyNode,
+          ref: '$ref/${method.name}/requestBody',
+        );
+        operation.requestBody.replace(requestBody);
+      }
+
+      final responsesNode = operationNode.nodes['responses'].getAs<YamlMap>();
+      if (responsesNode != null) {
+        responsesNode.checkAllowedFields([
+          'default',
+          _statusCodePattern,
+          _extensionPattern,
+        ]);
+
+        for (final entry in responsesNode.yamlNodes) {
+          final responseNode = entry.value.getAs<YamlMap>();
+          if (responseNode == null) {
+            throw Exception('OpenAPI response is not a map');
+          }
+
+          final response = _loadResponseOrRef(
+            responseNode,
+            ref: '$ref/${method.name}/responses/${entry.key}',
+          );
+          if (entry.key == 'default') {
+            operation.defaultResponse.replace(response);
+            continue;
+          }
+
+          final statusCode = StatusCodeOrRange.tryParse(entry.key);
+          if (statusCode == null) {
+            throw Exception(
+              'Invalid OpenAPI status code or range: ${entry.key}',
+            );
+          }
+          operation.responses[statusCode] = response;
+        }
+      }
+
+      final parametersNode =
+          operationNode.nodes['parameters'].getAs<YamlList>();
+      if (parametersNode != null) {
+        for (final (parameterIndex, parameterNode)
+            in parametersNode.nodes.indexed) {
+          if (parameterNode is! YamlMap) {
+            throw Exception('OpenAPI parameter is not a map');
+          }
+
+          final parameter = _loadParameterOrRef(
+            parameterNode,
+            ref: '$ref/${method.name}/parameters/$parameterIndex',
+          );
+          operation.parameters.add(parameter);
+        }
+      }
+
+      final serversNode = operationNode.nodes['servers'].getAs<YamlList>();
+      if (serversNode != null) {
+        for (final (serverIndex, serverNode) in serversNode.nodes.indexed) {
+          if (serverNode is! YamlMap) {
+            throw Exception('OpenAPI server is not a map');
+          }
+
+          final server = _loadServer(
+            serverNode,
+            ref: '$ref/${method.name}/servers/$serverIndex',
+          );
+          operation.servers.add(server.build());
+        }
+      }
+
+      path.operations[method] = operation.build();
+    }
+
+    return path.build();
+  }
+
+  OpenApiComponentOrRef<OpenApiSchema> _loadSchemaOrRef(
+    YamlMap schemaNode, {
+    required String ref,
+  }) {
+    if (schemaNode.nodes.containsKey(r'$ref')) {
+      return OpenApiComponentOrRef.reference(
+        ref: ref,
+        node: schemaNode,
+        reference: _ref<OpenApiSchema, OpenApiSchemaReference>(schemaNode),
+      );
+    }
+    return OpenApiComponentOrRef.component(
+      ref: ref,
+      component: _loadSchema(schemaNode, ref: ref),
+    );
+  }
+
+  OpenApiSchema _loadSchema(
+    YamlMap schemaNode, {
+    required String ref,
+  }) {
+    if (schemaNode.nodes.containsKey(r'$ref')) {
+      throw Exception('OpenAPI schema reference is not allowed');
+    }
+    schemaNode.checkAllowedFields([
+      'allOf',
+      'anyOf',
+      'const',
+      'contentEncoding', // TODO(dnys1): Implement
+      'contentMediaType', // Implement
+      'contentSchema', // Implement
+      'default',
+      'deprecated',
+      'description',
+      'discriminator',
+      'enum',
+      'example',
+      'exclusiveMaximum',
+      'exclusiveMinimum',
+      'externalDocs',
+      'format',
+      'items',
+      'maximum',
+      'maxItems',
+      'maxLength',
+      'maxProperties',
+      'minimum',
+      'minItems',
+      'minLength',
+      'minProperties',
+      'multipleOf',
+      // TODO(dnys1): Needed?
+      // 'not',
+      'nullable',
+      'oneOf',
+      'pattern',
+      'properties',
+      'additionalProperties',
+      'readOnly',
+      'required',
+      'title',
+      'type',
+      'uniqueItems',
+      'writeOnly',
+      _extensionPattern,
+    ]);
+
+    final yamlNodes = Map.fromEntries(schemaNode.yamlNodes);
+
+    OpenApiComponentOrRef<OpenApiSchema>? schema(String key) {
+      return yamlNodes[key]?.getAs<YamlMap>()?.let(
+            (node) => _loadSchemaOrRef(node, ref: '$ref/$key'),
+          );
+    }
+
+    Map<String, OpenApiComponentOrRef<OpenApiSchema>>? schemaMap(String key) {
+      return yamlNodes[key]?.getAs<YamlMap>()?.nodes.map(
+            (itemKey, node) => MapEntry(
+              switch (itemKey) {
+                final String key => key,
+                YamlScalar(value: final String key) => key,
+                _ => throw Exception('OpenAPI schema key is not a string'),
+              },
+              _loadSchemaOrRef(
+                node.getAs<YamlMap>()!,
+                ref: '$ref/$key/$itemKey',
+              ),
+            ),
+          );
+    }
+
+    Iterable<OpenApiComponentOrRef<OpenApiSchema>>? schemaList(String key) {
+      return yamlNodes[key]?.getAs<YamlList>()?.nodes.mapIndexed(
+            (index, node) => _loadSchemaOrRef(
+              node.getAs<YamlMap>()!,
+              ref: '$ref/$key/$index',
+            ),
+          );
+    }
+
+    Iterable<T>? scalarList<T extends Object?>(String key) =>
+        schemaNode.nodes[key]?.getAs<YamlList>()?.nodes.mapIndexed(
+              (index, node) => node.getScalar<T>(ref: '$ref/$key/$index'),
+            );
+
+    T? scalar<T extends Object?>(String key) => switch (schemaNode.nodes[key]) {
+          final YamlScalar scalar => scalar.getScalar<T>(ref: '$ref/$key'),
+          final YamlList list => list.value as T,
+          final node => node as T?,
+        };
+
+    OpenApiAdditionalProperties? additionalProperties;
+    if (yamlNodes['additionalProperties']
+        case final additionalPropertiesNode?) {
+      switch (additionalPropertiesNode) {
+        case YamlScalar(value: final bool allow):
+          additionalProperties = OpenApiAdditionalProperties(allow: allow);
+        case YamlMap():
+          additionalProperties = OpenApiAdditionalProperties(
+            schema: _loadSchemaOrRef(
+              additionalPropertiesNode,
+              ref: '$ref/additionalProperties',
+            ),
+          );
+      }
+    }
+
+    Map<String, Object?>? extensions;
+    for (final MapEntry(:key, value: valueNode) in yamlNodes.entries) {
+      if (!_extensionPattern.hasMatch(key)) {
+        continue;
+      }
+      extensions ??= {};
+      extensions[key] = valueNode.value;
+    }
+
+    final type = switch (yamlNodes['type']) {
+      final YamlScalar scalar => ItemValue(
+          JsonType.fromYaml(scalar.value as String),
+        ),
+      final YamlList list => ItemList(
+          list.nodes
+              .map((it) => it.getScalar<String>())
+              .map(JsonType.fromYaml)
+              .toList(),
+        ),
+      null => null,
+      _ => throw Exception('OpenAPI schema type is not a string or list'),
+    };
+
+    final discriminatorNode = yamlNodes['discriminator']?.getAs<YamlMap>();
+    OpenApiDiscriminator? discriminator;
+    if (discriminatorNode != null) {
+      discriminatorNode.checkRequiredFields([
+        'propertyName',
+      ]);
+      discriminatorNode.checkAllowedFields([
+        'mapping',
+        'propertyName',
+        _extensionPattern,
+      ]);
+      final discriminatorMap = Map.fromEntries(discriminatorNode.yamlNodes);
+      final mappingNode = discriminatorMap['mapping']?.getAs<YamlMap>();
+      discriminator = OpenApiDiscriminator(
+        ref: '$ref/discriminator',
+        node: discriminatorNode,
+        propertyName: discriminatorMap['propertyName'].getScalar(),
+        mapping: switch (mappingNode) {
+          final node? => {
+              for (final MapEntry(:key, :value) in node.yamlNodes)
+                key: value.getScalar(),
+            },
+          _ => null,
+        },
+      );
+    }
+
+    // TODO(dnys1): Give `const` it's own field.
+    final enumValues = scalarList<Object?>('enum') ??
+        scalar<Object?>('const')?.let((it) => [it]);
+
+    return OpenApiSchema(
+      ref: ref,
+      name:
+          ref.startsWith('#/components/schemas/') ? ref.split('/').last : null,
+      node: schemaNode,
+      type: type,
+      allOf: schemaList('allOf'),
+      anyOf: schemaList('anyOf'),
+      defaultValue: scalar('default'),
+      deprecated: scalar('deprecated'),
+      description: scalar('description'),
+      enumValues: enumValues,
+      exclusiveMaximum: scalar('exclusiveMaximum'),
+      exclusiveMinimum: scalar('exclusiveMinimum'),
+      format: scalar<String>('format')?.let(JsonTypeFormat.new),
+      items: schema('items'),
+      maximum: scalar('maximum'),
+      maxItems: scalar('maxItems'),
+      maxLength: scalar('maxLength'),
+      maxProperties: scalar('maxProperties'),
+      minimum: scalar('minimum'),
+      minItems: scalar('minItems'),
+      minLength: scalar('minLength'),
+      minProperties: scalar('minProperties'),
+      multipleOf: scalar('multipleOf'),
+      nullable: scalar('nullable'),
+      oneOf: schemaList('oneOf'),
+      pattern: scalar('pattern'),
+      properties: schemaMap('properties'),
+      additionalProperties: additionalProperties,
+      readOnly: scalar('readOnly'),
+      required: scalarList('required'),
+      title: scalar('title'),
+      uniqueItems: scalar('uniqueItems'),
+      writeOnly: scalar('writeOnly'),
+      discriminator: discriminator,
+      extensions: extensions,
+    );
+  }
+
+  OpenApiComponentOrRef<OpenApiResponse> _loadResponseOrRef(
+    YamlMap responseNode, {
+    required String ref,
+  }) {
+    if (responseNode.nodes.containsKey(r'$ref')) {
+      return OpenApiComponentOrRef.reference(
+        ref: ref,
+        node: responseNode,
+        reference:
+            _ref<OpenApiResponse, OpenApiResponseReference>(responseNode),
+      );
+    }
+    return OpenApiComponentOrRef.component(
+      ref: ref,
+      component: _loadResponse(responseNode, ref: ref),
+    );
+  }
+
+  OpenApiResponse _loadResponse(
+    YamlMap responseNode, {
+    required String ref,
+  }) {
+    if (responseNode.nodes.containsKey(r'$ref')) {
+      throw Exception('OpenAPI response reference is not allowed');
+    }
+
+    responseNode.checkAllowedFields([
+      'content',
+      'description',
+      'headers',
+      'links',
+      'content',
+      _extensionPattern,
+    ]);
+
+    final response = OpenApiResponseBuilder();
+    response
+      ..ref = ref
+      ..node = responseNode
+      ..description = responseNode.nodes['description']?.value as String?;
+
+    final contentNode = responseNode.nodes['content'].getAs<YamlMap>();
+    if (contentNode != null) {
+      contentNode.checkAllowedFields([
+        _mediaTypePattern,
+        _extensionPattern,
+      ]);
+
+      for (final entry in contentNode.yamlNodes) {
+        final mediaTypeNode = entry.value.getAs<YamlMap>();
+        if (mediaTypeNode == null) {
+          throw Exception('OpenAPI media type is not a map');
+        }
+
+        final mediaType = _loadMediaType(
+          mediaTypeNode,
+          ref: '$ref/content/${entry.key}',
+        );
+        response.content[MediaType.parse(entry.key)] = mediaType.build();
+      }
+    }
+
+    final headersNode = responseNode.nodes['headers'].getAs<YamlMap>();
+    if (headersNode != null) {
+      for (final entry in headersNode.yamlNodes) {
+        final headerNode = entry.value.getAs<YamlMap>();
+        if (headerNode == null) {
+          throw Exception('OpenAPI header is not a map');
+        }
+
+        final header = _loadHeaderOrRef(
+          headerNode,
+          ref: '$ref/headers/${entry.key}',
+        );
+        response.headers[entry.key] = header;
+      }
+    }
+
+    return response.build();
+  }
+
+  OpenApiComponentOrRef<OpenApiParameter> _loadParameterOrRef(
+    YamlMap parameterNode, {
+    required String ref,
+  }) {
+    if (parameterNode.nodes.containsKey(r'$ref')) {
+      return OpenApiComponentOrRef.reference(
+        ref: ref,
+        node: parameterNode,
+        reference: _ref<OpenApiParameter, OpenApiParameterReference>(
+          parameterNode,
+        ),
+      );
+    }
+    return OpenApiComponentOrRef.component(
+      ref: ref,
+      component: _loadParameter(parameterNode, ref: ref),
+    );
+  }
+
+  OpenApiParameter _loadParameter(
+    YamlMap parameterNode, {
+    required String ref,
+  }) {
+    if (parameterNode.nodes.containsKey(r'$ref')) {
+      throw Exception('OpenAPI parameter reference is not allowed');
+    }
+
+    parameterNode.checkRequiredFields(['in', 'name']);
+    parameterNode.checkAllowedFields([
+      'allowEmptyValue',
+      'allowReserved',
+      'content',
+      'deprecated',
+      'description',
+      'example',
+      'examples',
+      'explode',
+      'in',
+      'name',
+      'required',
+      'schema',
+      'style',
+      _extensionPattern,
+    ]);
+
+    final parameter = OpenApiParameterBuilder()
+      ..ref = ref
+      ..node = parameterNode;
+    final location = parameterNode.nodes['in'].getScalar<String>();
+    parameter.location = OpenApiParameterLocation.valueOf(location);
+    parameter.name = parameterNode.nodes['name'].getScalar();
+    parameter.description = parameterNode.nodes['description']?.getScalar();
+    parameter.required = parameterNode.nodes['required']?.getScalar();
+
+    final schemaNode = parameterNode.nodes['schema'].getAs<YamlMap>();
+    if (schemaNode != null) {
+      final schema = _loadSchemaOrRef(
+        schemaNode,
+        ref: '$ref/schema',
+      );
+      parameter.schema.replace(schema);
+    }
+
+    final contentNode = parameterNode.nodes['content'].getAs<YamlMap>();
+    if (contentNode != null) {
+      contentNode.checkRequiredFields([_mediaTypePattern]);
+      contentNode.checkAllowedFields([
+        _mediaTypePattern,
+        _extensionPattern,
+      ]);
+
+      if (contentNode.nodes.length > 1) {
+        throw Exception('OpenAPI header has multiple content types');
+      }
+
+      final MapEntry(key: contentType, value: node) =
+          contentNode.yamlNodes.first;
+      final mediaTypeNode = node.getAs<YamlMap>();
+      if (mediaTypeNode == null) {
+        throw Exception('OpenAPI media type was not provided');
+      }
+
+      final mediaType = _loadMediaType(
+        mediaTypeNode,
+        ref: '$ref/content/$contentType',
+      );
+      parameter.content = (
+        MediaType.parse(contentType),
+        mediaType.build(),
+      );
+    }
+
+    return parameter.build();
+  }
+
+  OpenApiComponentOrRef<OpenApiRequestBody> _loadRequestBodyOrRef(
+    YamlMap requestBodyNode, {
+    required String ref,
+  }) {
+    if (requestBodyNode.nodes.containsKey(r'$ref')) {
+      return OpenApiComponentOrRef.reference(
+        ref: ref,
+        node: requestBodyNode,
+        reference: _ref<OpenApiRequestBody, OpenApiRequestBodyReference>(
+          requestBodyNode,
+        ),
+      );
+    }
+    return OpenApiComponentOrRef.component(
+      ref: ref,
+      component: _loadRequestBody(requestBodyNode, ref: ref),
+    );
+  }
+
+  OpenApiRequestBody _loadRequestBody(
+    YamlMap requestBodyNode, {
+    required String ref,
+  }) {
+    if (requestBodyNode.nodes.containsKey(r'$ref')) {
+      throw Exception('OpenAPI request body reference is not allowed');
+    }
+
+    requestBodyNode.checkAllowedFields([
+      'content',
+      'description',
+      'required',
+      _extensionPattern,
+    ]);
+
+    final requestBody = OpenApiRequestBodyBuilder()
+      ..ref = ref
+      ..node = requestBodyNode;
+    requestBody.description =
+        requestBodyNode.nodes['description']?.value as String?;
+    requestBody.required = requestBodyNode.nodes['required']?.value as bool?;
+
+    final contentNode = requestBodyNode.nodes['content'].getAs<YamlMap>();
+    if (contentNode != null) {
+      contentNode.checkAllowedFields([
+        'examples',
+        _mediaTypePattern,
+        _extensionPattern,
+      ]);
+
+      for (final entry in contentNode.yamlNodes) {
+        final mediaTypeNode = entry.value.getAs<YamlMap>();
+        if (mediaTypeNode == null) {
+          throw Exception('OpenAPI media type is not a map');
+        }
+
+        final mediaType = _loadMediaType(
+          mediaTypeNode,
+          ref: '$ref/content/${entry.key}',
+        );
+        requestBody.content[MediaType.parse(entry.key)] = mediaType.build();
+      }
+    }
+
+    return requestBody.build();
+  }
+
+  OpenApiComponentOrRef<OpenApiHeader> _loadHeaderOrRef(
+    YamlMap headerNode, {
+    required String ref,
+  }) {
+    if (headerNode.nodes.containsKey(r'$ref')) {
+      return OpenApiComponentOrRef.reference(
+        ref: ref,
+        node: headerNode,
+        reference: _ref<OpenApiHeader, OpenApiHeaderReference>(headerNode),
+      );
+    }
+    return OpenApiComponentOrRef.component(
+      ref: ref,
+      component: _loadHeader(headerNode, ref: ref),
+    );
+  }
+
+  OpenApiHeader _loadHeader(
+    YamlMap headerNode, {
+    required String ref,
+  }) {
+    if (headerNode.nodes.containsKey(r'$ref')) {
+      throw Exception('OpenAPI header reference is not allowed');
+    }
+
+    headerNode.checkAllowedFields([
+      'allowEmptyValue',
+      'content',
+      'deprecated',
+      'description',
+      'example',
+      'examples',
+      'explode',
+      'required',
+      'schema',
+      'style',
+      _extensionPattern,
+    ]);
+
+    final header = OpenApiHeaderBuilder()
+      ..ref = ref
+      ..node = headerNode;
+    header.description = headerNode.nodes['description']?.value as String?;
+    header.required = headerNode.nodes['required']?.value as bool? ?? false;
+
+    final schemaNode = headerNode.nodes['schema'].getAs<YamlMap>();
+    if (schemaNode != null) {
+      final schema = _loadSchemaOrRef(
+        schemaNode,
+        ref: '$ref/schema',
+      );
+      header.schema.replace(schema);
+    }
+
+    final contentNode = headerNode.nodes['content'].getAs<YamlMap>();
+    if (contentNode != null) {
+      contentNode.checkRequiredFields([_mediaTypePattern]);
+      contentNode.checkAllowedFields([
+        _mediaTypePattern,
+        _extensionPattern,
+      ]);
+
+      if (contentNode.nodes.length > 1) {
+        throw Exception('OpenAPI header has multiple content types');
+      }
+
+      final MapEntry(key: contentType, value: node) =
+          contentNode.yamlNodes.first;
+      final mediaTypeNode = node.getAs<YamlMap>();
+      if (mediaTypeNode == null) {
+        throw Exception('OpenAPI media type was not provided');
+      }
+
+      final mediaType = _loadMediaType(
+        mediaTypeNode,
+        ref: '$ref/content/$contentType',
+      );
+      header.content = (
+        MediaType.parse(contentType),
+        mediaType.build(),
+      );
+    }
+
+    return header.build();
+  }
+
+  OpenApiMediaTypeBuilder _loadMediaType(
+    YamlMap mediaTypeNode, {
+    required String ref,
+  }) {
+    mediaTypeNode.checkRequiredFields(['schema']);
+    mediaTypeNode.checkAllowedFields([
+      'example',
+      'examples',
+      'encoding',
+      'schema',
+      _extensionPattern,
+    ]);
+
+    final mediaType = OpenApiMediaTypeBuilder()
+      ..ref = ref
+      ..node = mediaTypeNode;
+    // mediaType.example = mediaTypeNode.nodes['example']?.value as String?;
+    final schemaNode = mediaTypeNode.nodes['schema'].getAs<YamlMap>()!;
+    final schema = _loadSchemaOrRef(
+      schemaNode,
+      ref: '$ref/schema',
+    );
+    mediaType.schema.replace(schema);
+
+    final encodingNode = mediaTypeNode.nodes['encoding'].getAs<YamlMap>();
+    if (encodingNode != null) {
+      for (final entry in encodingNode.yamlNodes) {
+        final encodingNode = entry.value.getAs<YamlMap>()!;
+        encodingNode.checkAllowedFields([
+          'allowReserved',
+          'contentType',
+          'explode',
+          'headers',
+          'style',
+          _extensionPattern,
+        ]);
+
+        final encoding = OpenApiEncodingBuilder()
+          ..ref = '$ref/encoding/${entry.key}'
+          ..node = encodingNode
+          ..allowReserved = encodingNode.nodes['allowReserved']?.value as bool?;
+
+        var contentType = encodingNode.nodes['contentType']?.value as String?;
+        contentType ??= schema.defaultContentType(components);
+        encoding.contentType = MediaType.parse(contentType);
+
+        // https://spec.openapis.org/oas/v3.1.0#fixed-fields-12
+        const ignoreExplode = [
+          'application/x-www-form-urlencoded',
+          'multipart/form-data',
+        ];
+        if (!ignoreExplode.contains(contentType)) {
+          encoding.explode =
+              encodingNode.nodes['explode']?.value as bool? ?? false;
+        }
+
+        // https://spec.openapis.org/oas/v3.1.0#fixed-fields-12
+        const ignoreStyle = [
+          'application/x-www-form-urlencoded',
+          'multipart/form-data',
+        ];
+        if (!ignoreStyle.contains(contentType)) {
+          final style = encodingNode.nodes['style']?.value as String?;
+          if (style != null) {
+            encoding.style = OpenApiParameterStyle.valueOf(style);
+          }
+        }
+
+        final headersNode = encodingNode.nodes['headers'].getAs<YamlMap>();
+        if (headersNode != null) {
+          for (final headerEntry in headersNode.yamlNodes) {
+            final headerNode = headerEntry.value.getAs<YamlMap>();
+            if (headerNode == null) {
+              throw Exception('OpenAPI header is not a map');
+            }
+
+            final header = _loadHeaderOrRef(
+              headerNode,
+              ref: '$ref/encoding/${entry.key}/headers/${headerEntry.key}',
+            );
+            encoding.headers[headerEntry.key] = header;
+          }
+        }
+
+        mediaType.encoding[entry.key] = encoding.build();
+      }
+    }
+
+    return mediaType;
+  }
+
+  OpenApiSecurityScheme _loadSecurityScheme(
+    YamlMap securitySchemeNode, {
+    required String ref,
+  }) {
+    securitySchemeNode.checkRequiredFields(['type']);
+    securitySchemeNode.checkAllowedFields([
+      'type',
+      'description',
+      'name',
+      'in',
+      'scheme',
+      'bearerFormat',
+      'flows',
+      'openIdConnectUrl',
+      _extensionPattern,
+    ]);
+
+    final securityScheme = OpenApiSecuritySchemeBuilder()
+      ..ref = ref
+      ..node = securitySchemeNode;
+
+    final type = securitySchemeNode.nodes['type'].getScalar<String>();
+    securityScheme.type = OpenApiSecuritySchemeType.valueOf(type);
+
+    securityScheme.description =
+        securitySchemeNode.nodes['description']?.value as String?;
+    securityScheme.name = securitySchemeNode.nodes['name']?.value as String?;
+    if (securitySchemeNode.nodes['in']?.value case final String location) {
+      securityScheme.location = OpenApiParameterLocation.valueOf(location);
+    }
+    securityScheme.scheme =
+        securitySchemeNode.nodes['scheme']?.value as String?;
+    securityScheme.bearerFormat =
+        securitySchemeNode.nodes['bearerFormat']?.value as String?;
+    if (securitySchemeNode.nodes['flows'].getAs<YamlMap>()
+        case final flowsNode?) {
+      securityScheme.flows = _loadOAuthFlows(flowsNode, ref: '$ref/flows');
+    }
+    securityScheme.openIdConnectUrl =
+        securitySchemeNode.nodes['openIdConnectUrl']?.value as String?;
+
+    return securityScheme.build();
+  }
+
+  OpenApiOAuthFlowsBuilder _loadOAuthFlows(
+    YamlMap flowsNode, {
+    required String ref,
+  }) {
+    flowsNode.checkAllowedFields([
+      'implicit',
+      'password',
+      'clientCredentials',
+      'authorizationCode',
+      _extensionPattern,
+    ]);
+
+    final flows = OpenApiOAuthFlowsBuilder()
+      ..ref = ref
+      ..node = flowsNode;
+    if (flowsNode.nodes['authorizationCode']?.getAs<YamlMap>()
+        case final authorizationCodeNode?) {
+      flows.authorizationCode = _loadOAuthFlow(
+        authorizationCodeNode,
+        ref: '$ref/authorizationCode',
+      );
+    }
+    if (flowsNode.nodes['clientCredentials']?.getAs<YamlMap>()
+        case final clientCredentialsNode?) {
+      flows.clientCredentials = _loadOAuthFlow(
+        clientCredentialsNode,
+        ref: '$ref/clientCredentials',
+      );
+    }
+    if (flowsNode.nodes['implicit']?.getAs<YamlMap>()
+        case final implicitNode?) {
+      flows.implicit = _loadOAuthFlow(implicitNode, ref: '$ref/implicit');
+    }
+    if (flowsNode.nodes['password']?.getAs<YamlMap>()
+        case final passwordNode?) {
+      flows.password = _loadOAuthFlow(passwordNode, ref: '$ref/password');
+    }
+    return flows;
+  }
+
+  OpenApiOAuthFlowBuilder _loadOAuthFlow(
+    YamlMap flowNode, {
+    required String ref,
+  }) {
+    flowNode.checkAllowedFields([
+      'authorizationUrl',
+      'tokenUrl',
+      'refreshUrl',
+      'scopes',
+      _extensionPattern,
+    ]);
+
+    final flow = OpenApiOAuthFlowBuilder()
+      ..ref = ref
+      ..node = flowNode;
+    flow.authorizationUrl =
+        flowNode.nodes['authorizationUrl']?.value as String?;
+    flow.tokenUrl = flowNode.nodes['tokenUrl']?.value as String?;
+    flow.refreshUrl = flowNode.nodes['refreshUrl']?.value as String?;
+    flow.scopes.addEntries(
+      flowNode.nodes['scopes']
+          .getAs<YamlMap>()!
+          .yamlNodes
+          .map((entry) => MapEntry(entry.key, entry.value.getScalar<String>())),
+    );
+    return flow;
+  }
+}
+
+extension on OpenApiComponentOrRef<OpenApiSchema> {
+  String defaultContentType(OpenApiComponents components) {
+    final schema = resolve(components);
+    return switch (schema.type?.value) {
+      JsonType.object => 'application/json',
+      JsonType.array => schema.items!.defaultContentType(components),
+      _ => 'application/octet-stream',
+    };
+  }
+}
+
+extension on YamlMap {
+  Iterable<MapEntry<String, YamlNode>> get yamlNodes =>
+      nodes.entries.map((entry) {
+        final key = switch (entry.key) {
+          final String key => key,
+          YamlScalar(value: final String key) => key,
+          _ => throw Exception(
+              'Invalid key: $entry. Expected String or YamlScalar, '
+              // ignore: avoid_dynamic_calls
+              'got ${entry.key?.runtimeType}',
+            ),
+        };
+        return MapEntry(key, entry.value);
+      });
+}
+
+extension on YamlNode? {
+  T getScalar<T extends Object?>({
+    String? ref,
+  }) {
+    final this_ = this;
+    if (this_ is! YamlScalar) {
+      throw ArgumentError(
+        this_,
+        'Expected a YamlScalar but got a $runtimeType. '
+        'ref=$ref, context=${this_?.span.highlight()}',
+      );
+    }
+    final value = this_.value;
+    if (value is! T) {
+      if (T == String) {
+        switch (value) {
+          // TODO(dnys1): Improve... YAML decodes "- " in list as null
+          case null:
+            return '' as T;
+          // TODO(dnys1): Improve... YAML decodes "- true" in list as bool
+          case true || false:
+            return value.toString() as T;
+        }
+      }
+      throw ArgumentError(
+        this_,
+        'Expected a $T but got a $runtimeType. '
+        'ref=$ref, context=${this_.span.highlight()}',
+      );
+    }
+    return value;
+  }
+}
+
+extension on YamlNode? {
+  Node? getAs<Node extends YamlNode>() {
+    final this_ = this;
+    if (this_ == null) {
+      return null;
+    }
+    if (this_ is! Node) {
+      throw Exception('Expected a $Node but got a $runtimeType');
+    }
+    return this_;
+  }
+}
+
+extension on YamlMap {
+  void checkRequiredFields(Iterable<Pattern> requiredFields) {
+    final unmatched = List.of(requiredFields);
+    for (final MapEntry(:key) in value.entries) {
+      if (key is String) {
+        for (final requiredField in requiredFields) {
+          if (requiredField.allMatches(key).isNotEmpty) {
+            unmatched.remove(requiredField);
+            break;
+          }
+        }
+      }
+    }
+    if (unmatched.isNotEmpty) {
+      // TODO(dnys1): Use location in errors
+      // final location = span;
+      throw Exception('Missing required OpenAPI fields: $unmatched ($this)');
+    }
+  }
+
+  void checkAllowedFields(Iterable<Pattern> allowedPatterns) {
+    final invalid = <(String, YamlNode)>[];
+    for (final MapEntry(:key, value: node) in yamlNodes) {
+      var goodKey = false;
+      for (final allowedPattern in allowedPatterns) {
+        if (allowedPattern.allMatches(key).isNotEmpty) {
+          goodKey = true;
+          break;
+        }
+      }
+      if (!goodKey) {
+        invalid.add((key, node));
+      }
+    }
+    if (invalid.isNotEmpty) {
+      throw Exception('Invalid keys: $invalid ($this)');
+    }
+  }
+}
+
+extension<T> on T {
+  R let<R>(R Function(T) block) => block(this);
+}

--- a/apps/cli/lib/src/openapi/renderer/openapi_renderer.dart
+++ b/apps/cli/lib/src/openapi/renderer/openapi_renderer.dart
@@ -1,0 +1,744 @@
+import 'package:celest_cli/src/openapi/ast/openapi_ast.dart';
+import 'package:celest_cli/src/openapi/ast/openapi_visitor.dart';
+import 'package:source_span/source_span.dart';
+// ignore: implementation_imports
+import 'package:yaml/src/null_span.dart';
+import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+extension OpenApiRenderer on OpenApiDocument {
+  YamlDocument toYamlDocument() {
+    final renderer = _OpenApiDocumentRenderer();
+    final contents = accept(renderer);
+    final rendered = contents.toString();
+    return YamlDocument.internal(
+      contents,
+      SourceFile.fromString(rendered).span(0),
+      null,
+      const [],
+    );
+  }
+
+  String toYaml() {
+    final renderer = _OpenApiRenderer();
+    accept(renderer);
+    return renderer._editor.toString();
+  }
+}
+
+final class _OpenApiRenderer extends _OpenApiDocumentRenderer {
+  _OpenApiRenderer() : super(useCachedNode: false);
+
+  late final YamlEditor _editor;
+
+  @override
+  YamlNode visitDocument(OpenApiDocument document) {
+    _editor = YamlEditor('''
+openapi:
+info:
+servers:
+paths:
+components:
+  schemas:
+  responses:
+  parameters:
+  requestBodies:
+  headers:
+  paths:
+  securitySchemes:
+security:
+''');
+    // Always use the document version as specified if available.
+    final version = switch (document.node) {
+      final YamlMap node => YamlScalar.wrap(
+          node.nodes['openapi']?.value,
+          style: ScalarStyle.SINGLE_QUOTED,
+        ),
+      _ => YamlScalar.wrap(
+          document.version.toString(),
+          style: ScalarStyle.SINGLE_QUOTED,
+        ),
+    };
+    _editor.update(['openapi'], version);
+    _editor.update(['info'], document.info.accept(this));
+    if (document.servers.isNotEmpty) {
+      _editor.update(
+        ['servers'],
+        _list(
+          document.servers.map((server) => server.accept(this)).toList(),
+        ),
+      );
+    } else {
+      _editor.remove(['servers']);
+    }
+    if (document.paths.isNotEmpty) {
+      _editor.update(
+        ['paths'],
+        _map({
+          for (final entry in document.paths.entries)
+            YamlScalar.wrap(entry.key, style: ScalarStyle.SINGLE_QUOTED):
+                entry.value.accept(this),
+        }),
+      );
+    } else {
+      _editor.remove(['paths']);
+    }
+    if (document.components.schemas.isNotEmpty) {
+      _editor.update(
+        ['components', 'schemas'],
+        _map({
+          for (final entry in document.components.schemas.entries)
+            entry.key: entry.value.accept(this),
+        }),
+      );
+    } else {
+      _editor.remove(['components', 'schemas']);
+    }
+    if (document.components.responses.isNotEmpty) {
+      _editor.update(
+        ['components', 'responses'],
+        _map({
+          for (final entry in document.components.responses.entries)
+            entry.key: entry.value.accept(this),
+        }),
+      );
+    } else {
+      _editor.remove(['components', 'responses']);
+    }
+    if (document.components.parameters.isNotEmpty) {
+      _editor.update(
+        ['components', 'parameters'],
+        _map({
+          for (final entry in document.components.parameters.entries)
+            entry.key: entry.value.accept(this),
+        }),
+      );
+    } else {
+      _editor.remove(['components', 'parameters']);
+    }
+    if (document.components.requestBodies.isNotEmpty) {
+      _editor.update(
+        ['components', 'requestBodies'],
+        _map({
+          for (final entry in document.components.requestBodies.entries)
+            entry.key: entry.value.accept(this),
+        }),
+      );
+    } else {
+      _editor.remove(['components', 'requestBodies']);
+    }
+    if (document.components.headers.isNotEmpty) {
+      _editor.update(
+        ['components', 'headers'],
+        _map({
+          for (final entry in document.components.headers.entries)
+            entry.key: entry.value.accept(this),
+        }),
+      );
+    } else {
+      _editor.remove(['components', 'headers']);
+    }
+    if (document.components.paths.isNotEmpty) {
+      _editor.update(
+        ['components', 'paths'],
+        _map({
+          for (final entry in document.components.paths.entries)
+            YamlScalar.wrap(entry.key, style: ScalarStyle.SINGLE_QUOTED):
+                entry.value.accept(this),
+        }),
+      );
+    } else {
+      _editor.remove(['components', 'paths']);
+    }
+    if (document.components.securitySchemes.isNotEmpty) {
+      _editor.update(
+        ['components', 'securitySchemes'],
+        _map({
+          for (final entry in document.components.securitySchemes.entries)
+            entry.key: entry.value.accept(this),
+        }),
+      );
+    } else {
+      _editor.remove(['components', 'securitySchemes']);
+    }
+    if (document.securityRequirements.isNotEmpty) {
+      _editor.update(
+        ['security'],
+        _list(
+          document.securityRequirements
+              .map((requirement) => requirement.accept(this))
+              .toList(),
+        ),
+      );
+    } else {
+      _editor.remove(['security']);
+    }
+    return super.visitDocument(document);
+  }
+}
+
+YamlMap _map(Map<Object /* String | YamlNode */, Object> nodes) {
+  return wrapAsYamlNode(
+    nodes.map(
+      (key, value) => MapEntry(
+        key is YamlNode ? key : YamlScalar.wrap(key),
+        switch (value) {
+          YamlScalar(value: List() || Map()) => value.value,
+          _ => value,
+        },
+      ),
+    ),
+    collectionStyle: CollectionStyle.BLOCK,
+  ) as YamlMap;
+}
+
+YamlList _list(Iterable<YamlNode> nodes) {
+  return wrapAsYamlNode(
+    YamlList.internal(
+      nodes.toList(),
+      NullSpan(null),
+      CollectionStyle.BLOCK,
+    ),
+    collectionStyle: CollectionStyle.BLOCK,
+  ) as YamlList;
+}
+
+final class _OpenApiDocumentRenderer extends OpenApiVisitor<YamlNode> {
+  _OpenApiDocumentRenderer({
+    this.useCachedNode = true,
+  });
+
+  final bool useCachedNode;
+
+  @override
+  YamlNode visitDocument(OpenApiDocument document) {
+    if (document.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      'openapi': YamlScalar.wrap(
+        document.version.toString(),
+        style: ScalarStyle.SINGLE_QUOTED,
+      ),
+      'info': document.info.accept(this),
+      if (document.servers.isNotEmpty)
+        'servers': _list(
+          document.servers.map((server) => server.accept(this)),
+        ),
+      if (document.paths.isNotEmpty)
+        'paths': _map({
+          for (final entry in document.paths.entries)
+            YamlScalar.wrap(entry.key, style: ScalarStyle.SINGLE_QUOTED):
+                entry.value.accept(this),
+        }),
+      'components': document.components.accept(this),
+      if (document.securityRequirements.isNotEmpty)
+        'security': _list([
+          for (final requirement in document.securityRequirements)
+            requirement.accept(this),
+        ]),
+    });
+  }
+
+  @override
+  YamlNode visitComponents(OpenApiComponents components) {
+    if (components.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      'schemas': _map({
+        for (final entry in components.schemas.entries)
+          entry.key: entry.value.accept(this),
+      }),
+      'responses': _map({
+        for (final entry in components.responses.entries)
+          entry.key: entry.value.accept(this),
+      }),
+      'parameters': _map({
+        for (final entry in components.parameters.entries)
+          entry.key: entry.value.accept(this),
+      }),
+      'requestBodies': _map({
+        for (final entry in components.requestBodies.entries)
+          entry.key: entry.value.accept(this),
+      }),
+      'headers': _map({
+        for (final entry in components.headers.entries)
+          entry.key: entry.value.accept(this),
+      }),
+      'paths': _map({
+        for (final entry in components.paths.entries)
+          YamlScalar.wrap(entry.key, style: ScalarStyle.SINGLE_QUOTED):
+              entry.value.accept(this),
+      }),
+      'securitySchemes': _map({
+        for (final entry in components.securitySchemes.entries)
+          entry.key: entry.value.accept(this),
+      }),
+    });
+  }
+
+  @override
+  YamlNode visitDiscriminator(OpenApiDiscriminator discriminator) {
+    if (discriminator.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      'propertyName': YamlScalar.wrap(discriminator.propertyName),
+      if (discriminator.mapping case final mapping? when mapping.isNotEmpty)
+        'mapping': _map({
+          for (final entry in mapping.entries)
+            entry.key: YamlScalar.wrap(
+              entry.value,
+              style: ScalarStyle.SINGLE_QUOTED,
+            ),
+        }),
+    });
+  }
+
+  @override
+  YamlNode visitEncoding(OpenApiEncoding encoding) {
+    if (encoding.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      'contentType': YamlScalar.wrap(encoding.contentType.toString()),
+      if (encoding.headers.isNotEmpty)
+        'headers': _map({
+          for (final entry in encoding.headers.entries)
+            entry.key: entry.value.accept(this),
+        }),
+      if (encoding.style case final style?)
+        'style': YamlScalar.wrap(style.name),
+      if (encoding.explode) 'explode': YamlScalar.wrap(encoding.explode),
+      if (encoding.allowReserved)
+        'allowReserved': YamlScalar.wrap(encoding.allowReserved),
+    });
+  }
+
+  @override
+  YamlNode visitHeader(OpenApiHeader header) {
+    if (header.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      if (header.description != null)
+        'description': YamlScalar.wrap(
+          header.description,
+          style: ScalarStyle.LITERAL,
+        ),
+      if (header.required) 'required': YamlScalar.wrap(header.required),
+      if (header.deprecated) 'deprecated': YamlScalar.wrap(header.deprecated),
+      if (header.allowEmptyValue)
+        'allowEmptyValue': YamlScalar.wrap(header.allowEmptyValue),
+      if (header.style case final style?) 'style': YamlScalar.wrap(style.name),
+      if (header.explode case final explode?)
+        'explode': YamlScalar.wrap(explode),
+      if (header.allowReserved case final allowReserved?)
+        'allowReserved': YamlScalar.wrap(allowReserved),
+      if (header.schema case final schema) 'schema': schema.accept(this),
+      if (header.content case final content?)
+        'content': _map({
+          content.$1.toString(): content.$2.accept(this),
+        }),
+    });
+  }
+
+  @override
+  YamlNode visitInfo(OpenApiInfo info) {
+    if (info.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      if (info.title != null) 'title': YamlScalar.wrap(info.title),
+      if (info.description != null)
+        'description': YamlScalar.wrap(
+          info.description,
+          style: ScalarStyle.LITERAL,
+        ),
+      if (info.apiVersion != null)
+        'version': YamlScalar.wrap(
+          info.apiVersion,
+          style: ScalarStyle.SINGLE_QUOTED,
+        ),
+    });
+  }
+
+  @override
+  YamlNode visitMediaType(OpenApiMediaType mediaType) {
+    if (mediaType.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      'schema': mediaType.schema.accept(this),
+      if (mediaType.encoding.isNotEmpty)
+        'encoding': _map({
+          for (final entry in mediaType.encoding.entries)
+            entry.key: entry.value.accept(this),
+        }),
+    });
+  }
+
+  @override
+  YamlNode visitOperation(OpenApiOperation operation) {
+    if (operation.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      if (operation.summary != null)
+        'summary': YamlScalar.wrap(operation.summary),
+      if (operation.description != null)
+        'description': YamlScalar.wrap(
+          operation.description,
+          style: ScalarStyle.LITERAL,
+        ),
+      if (operation.deprecated)
+        'deprecated': YamlScalar.wrap(operation.deprecated),
+      if (operation.operationId != null)
+        'operationId': YamlScalar.wrap(operation.operationId),
+      if (operation.parameters.isNotEmpty)
+        'parameters': _list(
+          operation.parameters
+              .map((parameter) => parameter.accept(this))
+              .toList(),
+        ),
+      if (operation.requestBody case final requestBody?)
+        'requestBody': requestBody.accept(this),
+      if (operation.responses.isNotEmpty || operation.defaultResponse != null)
+        'responses': _map({
+          for (final entry in operation.responses.entries)
+            YamlScalar.wrap(
+              entry.key.toString(),
+              style: ScalarStyle.SINGLE_QUOTED,
+            ): entry.value.accept(this),
+          if (operation.defaultResponse case final defaultResponse?)
+            'default': defaultResponse.accept(this),
+        }),
+      if (operation.servers case final servers? when servers.isNotEmpty)
+        'servers': _list(
+          servers.map((server) => server.accept(this)).toList(),
+        ),
+    });
+  }
+
+  @override
+  YamlNode visitParameter(OpenApiParameter parameter) {
+    if (parameter.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      'name': YamlScalar.wrap(parameter.name),
+      'in': YamlScalar.wrap(parameter.location.name),
+      'required': YamlScalar.wrap(parameter.required),
+      if (parameter.description != null)
+        'description': YamlScalar.wrap(
+          parameter.description,
+          style: ScalarStyle.LITERAL,
+        ),
+      if (parameter.deprecated)
+        'deprecated': YamlScalar.wrap(parameter.deprecated),
+      if (parameter.allowEmptyValue)
+        'allowEmptyValue': YamlScalar.wrap(parameter.allowEmptyValue),
+      if (parameter.style case final style?)
+        'style': YamlScalar.wrap(style.name),
+      if (parameter.explode case final explode?)
+        'explode': YamlScalar.wrap(explode),
+      if (parameter.allowReserved case final allowReserved?)
+        'allowReserved': YamlScalar.wrap(allowReserved),
+      if (parameter.schema case final schema?) 'schema': schema.accept(this),
+      if (parameter.content case final content?)
+        'content': _map({
+          content.$1.toString(): content.$2.accept(this),
+        }),
+    });
+  }
+
+  @override
+  YamlNode visitPathItem(OpenApiPathItem pathItem) {
+    if (pathItem.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      for (final operation in pathItem.operations.values)
+        operation.type.name: operation.accept(this),
+      if (pathItem.parameters.isNotEmpty)
+        'parameters': _list(
+          pathItem.parameters
+              .map((parameter) => parameter.accept(this))
+              .toList(),
+        ),
+      if (pathItem.servers case final servers? when servers.isNotEmpty)
+        'servers': _list(
+          servers.map((server) => server.accept(this)).toList(),
+        ),
+    });
+  }
+
+  @override
+  YamlNode visitReference(OpenApiReference reference) {
+    if (reference.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      r'$ref': YamlScalar.wrap(
+        reference.ref,
+        style: ScalarStyle.SINGLE_QUOTED,
+      ),
+    });
+  }
+
+  @override
+  YamlNode visitRequestBody(OpenApiRequestBody requestBody) {
+    if (requestBody.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      if (requestBody.description != null)
+        'description': YamlScalar.wrap(
+          requestBody.description,
+          style: ScalarStyle.LITERAL,
+        ),
+      if (requestBody.content.isNotEmpty)
+        'content': _map({
+          for (final entry in requestBody.content.entries)
+            entry.key.toString(): entry.value.accept(this),
+        }),
+      if (requestBody.required)
+        'required': YamlScalar.wrap(requestBody.required),
+    });
+  }
+
+  @override
+  YamlNode visitResponse(OpenApiResponse response) {
+    if (response.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      'description': YamlScalar.wrap(
+        response.description,
+        style: ScalarStyle.LITERAL,
+      ),
+      if (response.content.isNotEmpty)
+        'content': _map({
+          for (final entry in response.content.entries)
+            entry.key.toString(): entry.value.accept(this),
+        }),
+      if (response.headers.isNotEmpty)
+        'headers': _map({
+          for (final entry in response.headers.entries)
+            entry.key: entry.value.accept(this),
+        }),
+    });
+  }
+
+  @override
+  YamlNode visitSchema(OpenApiSchema schema) {
+    if (schema.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      if (schema.title != null) 'title': YamlScalar.wrap(schema.title),
+      if (schema.description != null)
+        'description': YamlScalar.wrap(
+          schema.description,
+          style: ScalarStyle.LITERAL,
+        ),
+      if (schema.type case final type?)
+        'type': switch (type) {
+          ItemValue() => YamlScalar.wrap(type.value.toYaml()),
+          ItemList() => _list(type.map((it) => YamlScalar.wrap(it.toYaml()))),
+        },
+      if (schema.nullable case final nullable?)
+        'nullable': YamlScalar.wrap(nullable),
+      if (schema.allOf case final allOf? when allOf.isNotEmpty)
+        'allOf': _list(
+          allOf.map((schema) => schema.accept(this)).toList(),
+        ),
+      if (schema.oneOf case final oneOf? when oneOf.isNotEmpty)
+        'oneOf': _list(
+          oneOf.map((schema) => schema.accept(this)).toList(),
+        ),
+      if (schema.anyOf case final anyOf? when anyOf.isNotEmpty)
+        'anyOf': _list(
+          anyOf.map((schema) => schema.accept(this)).toList(),
+        ),
+      if (schema.items case final items?) 'items': items.accept(this),
+      if (schema.maxItems case final maxItems?)
+        'maxItems': YamlScalar.wrap(maxItems),
+      if (schema.minItems case final minItems?)
+        'minItems': YamlScalar.wrap(minItems),
+      if (schema.uniqueItems case final uniqueItems?)
+        'uniqueItems': YamlScalar.wrap(uniqueItems),
+      if (schema.properties case final properties? when properties.isNotEmpty)
+        'properties': _map({
+          for (final entry in properties.entries)
+            entry.key: entry.value.accept(this),
+        }),
+      if (schema.additionalProperties case final additionalProperties?)
+        'additionalProperties': additionalProperties.accept(this),
+      if (schema.minProperties case final minProperties?)
+        'minProperties': YamlScalar.wrap(minProperties),
+      if (schema.maxProperties case final maxProperties?)
+        'maxProperties': YamlScalar.wrap(maxProperties),
+      if (schema.required case final required? when required.isNotEmpty)
+        'required': _list(required.map(YamlScalar.wrap)),
+      if (schema.format case final format?) 'format': YamlScalar.wrap(format),
+      if (schema.multipleOf case final multipleOf?)
+        'multipleOf': YamlScalar.wrap(multipleOf),
+      if (schema.maximum case final maximum?)
+        'maximum': YamlScalar.wrap(maximum),
+      if (schema.exclusiveMaximum case final exclusiveMaximum?)
+        'exclusiveMaximum': YamlScalar.wrap(exclusiveMaximum),
+      if (schema.minimum case final minimum?)
+        'minimum': YamlScalar.wrap(minimum),
+      if (schema.exclusiveMinimum case final exclusiveMinimum?)
+        'exclusiveMinimum': YamlScalar.wrap(exclusiveMinimum),
+      if (schema.maxLength case final maxLength?)
+        'maxLength': YamlScalar.wrap(maxLength),
+      if (schema.minLength case final minLength?)
+        'minLength': YamlScalar.wrap(minLength),
+      if (schema.pattern != null) 'pattern': YamlScalar.wrap(schema.pattern),
+      if (schema.enumValues case final enumValues? when enumValues.isNotEmpty)
+        'enum': _list(enumValues.map(YamlScalar.wrap)),
+      if (schema.discriminator case final discriminator?)
+        'discriminator': discriminator.accept(this),
+      if (schema.deprecated case final deprecated?)
+        'deprecated': YamlScalar.wrap(deprecated),
+      if (schema.defaultValue case final defaultValue?)
+        'default': wrapAsYamlNode(
+          defaultValue,
+          collectionStyle: CollectionStyle.FLOW,
+          scalarStyle: ScalarStyle.PLAIN,
+        ),
+      if (schema.readOnly case final readOnly?)
+        'readOnly': YamlScalar.wrap(readOnly),
+      if (schema.writeOnly case final writeOnly?)
+        'writeOnly': YamlScalar.wrap(writeOnly),
+      if (schema.extensions case final extensions?)
+        for (final extension in extensions.entries)
+          extension.key: wrapAsYamlNode(extension.value.value),
+    });
+  }
+
+  @override
+  YamlNode visitAdditionalProperties(
+    OpenApiAdditionalProperties additionalProperties,
+  ) {
+    if (additionalProperties.node case final node? when useCachedNode) {
+      return node;
+    }
+    if (additionalProperties.allow case final allow?) {
+      return YamlScalar.wrap(allow);
+    }
+    if (additionalProperties.schema case final schema?) {
+      return schema.accept(this);
+    }
+    throw StateError(
+      'Expected either allow or schema, got $additionalProperties',
+    );
+  }
+
+  @override
+  YamlNode visitServer(OpenApiServer server) {
+    if (server.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      'url': YamlScalar.wrap(server.url),
+      if (server.description != null)
+        'description': YamlScalar.wrap(server.description),
+      if (server.variables.isNotEmpty)
+        'variables': _map({
+          for (final MapEntry(:key, :value) in server.variables.entries)
+            key: value.accept(this),
+        }),
+    });
+  }
+
+  @override
+  YamlNode visitServerVariable(OpenApiServerVariable serverVariable) {
+    if (serverVariable.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      'default': YamlScalar.wrap(serverVariable.defaultValue),
+      if (serverVariable.enumValues case final enumValues?
+          when enumValues.isNotEmpty)
+        'enum': _list(enumValues.map(YamlScalar.wrap)),
+      if (serverVariable.description != null)
+        'description': YamlScalar.wrap(serverVariable.description),
+    });
+  }
+
+  @override
+  YamlNode visitOAuthFlow(OpenApiOAuthFlow oauthFlow) {
+    if (oauthFlow.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      if (oauthFlow.authorizationUrl case final authorizationUrl?)
+        'authorizationUrl': YamlScalar.wrap(authorizationUrl),
+      if (oauthFlow.tokenUrl case final tokenUrl?)
+        'tokenUrl': YamlScalar.wrap(tokenUrl),
+      if (oauthFlow.refreshUrl case final refreshUrl?)
+        'refreshUrl': YamlScalar.wrap(refreshUrl),
+      if (oauthFlow.scopes.isNotEmpty)
+        'scopes': _map({
+          for (final entry in oauthFlow.scopes.entries)
+            entry.key: YamlScalar.wrap(entry.value),
+        }),
+    });
+  }
+
+  @override
+  YamlNode visitOAuthFlows(OpenApiOAuthFlows oauthFlows) {
+    if (oauthFlows.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      if (oauthFlows.implicit case final implicit?)
+        'implicit': implicit.accept(this),
+      if (oauthFlows.password case final password?)
+        'password': password.accept(this),
+      if (oauthFlows.clientCredentials case final clientCredentials?)
+        'clientCredentials': clientCredentials.accept(this),
+      if (oauthFlows.authorizationCode case final authorizationCode?)
+        'authorizationCode': authorizationCode.accept(this),
+    });
+  }
+
+  @override
+  YamlNode visitSecurityScheme(OpenApiSecurityScheme securityScheme) {
+    if (securityScheme.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      'type': YamlScalar.wrap(securityScheme.type.name),
+      if (securityScheme.description case final description?)
+        'description': YamlScalar.wrap(description),
+      if (securityScheme.name case final name?) 'name': YamlScalar.wrap(name),
+      if (securityScheme.location case final location?)
+        'in': YamlScalar.wrap(location.name),
+      if (securityScheme.scheme case final scheme?)
+        'scheme': YamlScalar.wrap(scheme),
+      if (securityScheme.bearerFormat case final bearerFormat?)
+        'bearerFormat': YamlScalar.wrap(bearerFormat),
+      if (securityScheme.flows case final flows?) 'flows': flows.accept(this),
+      if (securityScheme.openIdConnectUrl case final openIdConnectUrl?)
+        'openIdConnectUrl': YamlScalar.wrap(openIdConnectUrl),
+    });
+  }
+
+  @override
+  YamlNode visitSecurityRequirement(
+    OpenApiSecurityRequirement securityRequirement,
+  ) {
+    if (securityRequirement.node case final node? when useCachedNode) {
+      return node;
+    }
+    return _map({
+      for (final entry in securityRequirement.schemes.entries)
+        entry.key: _list(entry.value.map(YamlScalar.wrap)),
+    });
+  }
+}

--- a/apps/cli/lib/src/openapi/type/json_type.dart
+++ b/apps/cli/lib/src/openapi/type/json_type.dart
@@ -1,0 +1,34 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'json_type.g.dart';
+
+class JsonType extends EnumClass {
+  const JsonType._(super.name);
+
+  static const JsonType array = _$array;
+  static const JsonType object = _$object;
+  static const JsonType boolean = _$boolean;
+  static const JsonType number = _$number;
+  static const JsonType integer = _$integer;
+  static const JsonType string = _$string;
+
+  @BuiltValueEnumConst(wireName: 'null')
+  static const JsonType null$ = _$null$;
+
+  static BuiltSet<JsonType> get values => _$JsonTypeValues;
+  static JsonType valueOf(String name) => _$JsonTypeValueOf(name);
+
+  static JsonType fromYaml(String yaml) => switch (yaml) {
+        'null' => null$,
+        _ => valueOf(yaml),
+      };
+
+  String toYaml() => switch (this) {
+        null$ => 'null',
+        _ => name,
+      };
+
+  static Serializer<JsonType> get serializer => _$jsonTypeSerializer;
+}

--- a/apps/cli/lib/src/openapi/type/json_type.g.dart
+++ b/apps/cli/lib/src/openapi/type/json_type.g.dart
@@ -1,0 +1,76 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'json_type.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+const JsonType _$array = const JsonType._('array');
+const JsonType _$object = const JsonType._('object');
+const JsonType _$boolean = const JsonType._('boolean');
+const JsonType _$number = const JsonType._('number');
+const JsonType _$integer = const JsonType._('integer');
+const JsonType _$string = const JsonType._('string');
+const JsonType _$null$ = const JsonType._('null\$');
+
+JsonType _$JsonTypeValueOf(String name) {
+  switch (name) {
+    case 'array':
+      return _$array;
+    case 'object':
+      return _$object;
+    case 'boolean':
+      return _$boolean;
+    case 'number':
+      return _$number;
+    case 'integer':
+      return _$integer;
+    case 'string':
+      return _$string;
+    case 'null\$':
+      return _$null$;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<JsonType> _$JsonTypeValues =
+    new BuiltSet<JsonType>(const <JsonType>[
+  _$array,
+  _$object,
+  _$boolean,
+  _$number,
+  _$integer,
+  _$string,
+  _$null$,
+]);
+
+Serializer<JsonType> _$jsonTypeSerializer = new _$JsonTypeSerializer();
+
+class _$JsonTypeSerializer implements PrimitiveSerializer<JsonType> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    'null\$': 'null',
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    'null': 'null\$',
+  };
+
+  @override
+  final Iterable<Type> types = const <Type>[JsonType];
+  @override
+  final String wireName = 'JsonType';
+
+  @override
+  Object serialize(Serializers serializers, JsonType object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      _toWire[object.name] ?? object.name;
+
+  @override
+  JsonType deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      JsonType.valueOf(
+          _fromWire[serialized] ?? (serialized is String ? serialized : ''));
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/cli/lib/src/openapi/type/json_type_format.spec.dart
+++ b/apps/cli/lib/src/openapi/type/json_type_format.spec.dart
@@ -1,0 +1,280 @@
+// GENERATED CODE - run `tool/update_spec.dart` to update.
+// ignore_for_file: type=lint
+
+import 'json_type.dart';
+
+extension type const JsonTypeFormat(String _) implements String {
+  /// Base64url: Binary data encoded as a url-safe string as defined in [RFC4648](https://www.rfc-editor.org/rfc/rfc4648#section-5)
+  static const JsonTypeFormat base64url = JsonTypeFormat('base64url');
+
+  /// Binary: any sequence of octets
+  static const JsonTypeFormat binary = JsonTypeFormat('binary');
+
+  /// Byte: base64 encoded data as defined in [RFC4648](https://www.rfc-editor.org/rfc/rfc4648#section-4)
+  static const JsonTypeFormat byte = JsonTypeFormat('byte');
+
+  /// Char: A single character
+  static const JsonTypeFormat char = JsonTypeFormat('char');
+
+  /// Commonmark: commonmark-formatted text
+  static const JsonTypeFormat commonmark = JsonTypeFormat('commonmark');
+
+  /// Date Time: date and time as defined by date-time - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
+  static const JsonTypeFormat dateTime = JsonTypeFormat('date-time');
+
+  /// Date: date as defined by full-date - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
+  static const JsonTypeFormat date = JsonTypeFormat('date');
+
+  /// Decimal: A fixed point decimal number of unspecified precision and range
+  static const JsonTypeFormat decimal = JsonTypeFormat('decimal');
+
+  /// Decimal128: A decimal floating-point number with 34 significant decimal digits
+  static const JsonTypeFormat decimal128 = JsonTypeFormat('decimal128');
+
+  /// Double Int: an integer that can be stored in an IEEE 754 double-precision number without loss of precision
+  static const JsonTypeFormat doubleInt = JsonTypeFormat('double-int');
+
+  /// Double: double precision floating point number
+  static const JsonTypeFormat double = JsonTypeFormat('double');
+
+  /// Duration: duration as defined by duration - RFC3339
+  static const JsonTypeFormat duration = JsonTypeFormat('duration');
+
+  /// Email: An email address as defined as Mailbox in RFC5321
+  static const JsonTypeFormat email = JsonTypeFormat('email');
+
+  /// Float: single precision floating point number
+  static const JsonTypeFormat float = JsonTypeFormat('float');
+
+  /// Hostname: A host name as defined by RFC1123
+  static const JsonTypeFormat hostname = JsonTypeFormat('hostname');
+
+  /// Html: HTML-formatted text
+  static const JsonTypeFormat html = JsonTypeFormat('html');
+
+  /// Http Date: date and time as defined by HTTP-date - [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1)
+  static const JsonTypeFormat httpDate = JsonTypeFormat('http-date');
+
+  /// Idn Email: An email address as defined as Mailbox in RFC6531
+  static const JsonTypeFormat idnEmail = JsonTypeFormat('idn-email');
+
+  /// Idn Hostname: An internationalized host name as defined by RFC5890
+  static const JsonTypeFormat idnHostname = JsonTypeFormat('idn-hostname');
+
+  /// Int16: signed 16-bit integer
+  static const JsonTypeFormat int16 = JsonTypeFormat('int16');
+
+  /// Int32: signed 32-bit integer
+  static const JsonTypeFormat int32 = JsonTypeFormat('int32');
+
+  /// Int64: signed 64-bit integer
+  static const JsonTypeFormat int64 = JsonTypeFormat('int64');
+
+  /// Int8: signed 8-bit integer
+  static const JsonTypeFormat int8 = JsonTypeFormat('int8');
+
+  /// Ipv4: An IPv4 address as defined as dotted-quad by RFC2673
+  static const JsonTypeFormat ipv4 = JsonTypeFormat('ipv4');
+
+  /// Ipv6: An IPv6 address as defined by RFC4673
+  static const JsonTypeFormat ipv6 = JsonTypeFormat('ipv6');
+
+  /// Iri Reference: A Internationalized Resource Identifier as defined in RFC3987
+  static const JsonTypeFormat iriReference = JsonTypeFormat('iri-reference');
+
+  /// Iri: A Internationalized Resource Identifier as defined in RFC3987
+  static const JsonTypeFormat iri = JsonTypeFormat('iri');
+
+  /// Json Pointer: A JSON string representation of a JSON Pointer as defined in RFC6901
+  static const JsonTypeFormat jsonPointer = JsonTypeFormat('json-pointer');
+
+  /// Media Range: A media type as defined by the `media-range` ABNF production in RFC9110.
+  static const JsonTypeFormat mediaRange = JsonTypeFormat('media-range');
+
+  /// Password: a string that hints to obscure the value.
+  static const JsonTypeFormat password = JsonTypeFormat('password');
+
+  /// Regex: A regular expression as defined in ECMA-262
+  static const JsonTypeFormat regex = JsonTypeFormat('regex');
+
+  /// Relative Json Pointer: A JSON string representation of a relative JSON Pointer as defined in draft RFC 01
+  static const JsonTypeFormat relativeJsonPointer =
+      JsonTypeFormat('relative-json-pointer');
+
+  /// Sf Binary: structured fields byte sequence as defined in [RFC8941]
+  static const JsonTypeFormat sfBinary = JsonTypeFormat('sf-binary');
+
+  /// Sf Boolean: structured fields boolean as defined in [RFC8941]
+  static const JsonTypeFormat sfBoolean = JsonTypeFormat('sf-boolean');
+
+  /// Sf Decimal: structured fields decimal as defined in [RFC8941]
+  static const JsonTypeFormat sfDecimal = JsonTypeFormat('sf-decimal');
+
+  /// Sf Integer: structured fields integer as defined in [RFC8941]
+  static const JsonTypeFormat sfInteger = JsonTypeFormat('sf-integer');
+
+  /// Sf String: structured fields string as defined in [RFC8941]
+  static const JsonTypeFormat sfString = JsonTypeFormat('sf-string');
+
+  /// Sf Token: structured fields token as defined in [RFC8941]
+  static const JsonTypeFormat sfToken = JsonTypeFormat('sf-token');
+
+  /// Time: time as defined by full-time - RFC3339
+  static const JsonTypeFormat time = JsonTypeFormat('time');
+
+  /// Uint8: unsigned 8-bit integer
+  static const JsonTypeFormat uint8 = JsonTypeFormat('uint8');
+
+  /// Uri Reference: A URI reference as defined in [RFC3986](https://www.rfc-editor.org/info/rfc3986)
+  static const JsonTypeFormat uriReference = JsonTypeFormat('uri-reference');
+
+  /// Uri Template: A URI Template as defined in RFC6570
+  static const JsonTypeFormat uriTemplate = JsonTypeFormat('uri-template');
+
+  /// Uri: A Uniform Resource Identifier as defined in RFC3986
+  static const JsonTypeFormat uri = JsonTypeFormat('uri');
+
+  /// Uuid: A Universally Unique IDentifier as defined in RFC4122
+  static const JsonTypeFormat uuid = JsonTypeFormat('uuid');
+
+  /// Valid base types for this format.
+  List<JsonType>? get baseTypes => switch (this) {
+        JsonTypeFormat.base64url => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.binary => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.byte => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.char => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.commonmark => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.dateTime => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.date => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.decimal => [
+            JsonType.string,
+            JsonType.number,
+          ],
+        JsonTypeFormat.decimal128 => [
+            JsonType.string,
+            JsonType.number,
+          ],
+        JsonTypeFormat.doubleInt => [
+            JsonType.integer,
+          ],
+        JsonTypeFormat.double => [
+            JsonType.number,
+          ],
+        JsonTypeFormat.duration => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.email => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.float => [
+            JsonType.number,
+          ],
+        JsonTypeFormat.hostname => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.html => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.httpDate => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.idnEmail => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.idnHostname => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.int16 => [
+            JsonType.number,
+          ],
+        JsonTypeFormat.int32 => [
+            JsonType.number,
+          ],
+        JsonTypeFormat.int64 => [
+            JsonType.number,
+            JsonType.string,
+          ],
+        JsonTypeFormat.int8 => [
+            JsonType.number,
+          ],
+        JsonTypeFormat.ipv4 => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.ipv6 => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.iriReference => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.iri => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.jsonPointer => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.mediaRange => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.password => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.regex => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.relativeJsonPointer => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.sfBinary => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.sfBoolean => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.sfDecimal => [
+            JsonType.number,
+          ],
+        JsonTypeFormat.sfInteger => [
+            JsonType.integer,
+            JsonType.number,
+          ],
+        JsonTypeFormat.sfString => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.sfToken => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.time => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.uint8 => [
+            JsonType.number,
+          ],
+        JsonTypeFormat.uriReference => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.uriTemplate => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.uri => [
+            JsonType.string,
+          ],
+        JsonTypeFormat.uuid => [
+            JsonType.string,
+          ],
+        _ => null,
+      };
+}

--- a/apps/cli/lib/src/openapi/type/json_type_schema.dart
+++ b/apps/cli/lib/src/openapi/type/json_type_schema.dart
@@ -1,0 +1,300 @@
+// ignore_for_file: avoid_positional_boolean_parameters
+
+import 'package:celest_cli/src/openapi/type/json_type_format.spec.dart';
+
+/// A structural specification of a JSON type.
+///
+/// This class and all its subtypes should be identifiable based on its structure
+/// alone which allows for efficient linking later. No non-structural metadata
+/// should be included in the type schema.
+sealed class JsonTypeSchema {
+  const JsonTypeSchema({
+    required bool? isNullable,
+    Map<String, Object?>? extensions,
+  })  : isNullable = isNullable ?? false,
+        extensions = extensions ?? const {};
+
+  final bool isNullable;
+  final Map<String, Object?> extensions;
+
+  JsonTypeSchema withNullability(bool isNullable);
+}
+
+final class JsonBooleanType extends JsonTypeSchema {
+  const JsonBooleanType({
+    required super.isNullable,
+    super.extensions,
+  });
+
+  @override
+  JsonBooleanType withNullability(bool isNullable) {
+    return JsonBooleanType(
+      isNullable: isNullable,
+      extensions: extensions,
+    );
+  }
+}
+
+final class JsonIntegerType extends JsonTypeSchema {
+  const JsonIntegerType({
+    required super.isNullable,
+    this.format,
+    super.extensions,
+  });
+
+  final JsonTypeFormat? format;
+
+  @override
+  JsonIntegerType withNullability(bool isNullable) {
+    return JsonIntegerType(
+      isNullable: isNullable,
+      format: format,
+      extensions: extensions,
+    );
+  }
+}
+
+final class JsonNumberType extends JsonTypeSchema {
+  const JsonNumberType({
+    required super.isNullable,
+    this.format,
+    super.extensions,
+  });
+
+  final JsonTypeFormat? format;
+
+  @override
+  JsonNumberType withNullability(bool isNullable) {
+    return JsonNumberType(
+      isNullable: isNullable,
+      format: format,
+      extensions: extensions,
+    );
+  }
+}
+
+final class JsonStringType extends JsonTypeSchema {
+  const JsonStringType({
+    required super.isNullable,
+    this.format,
+    super.extensions,
+  });
+
+  final JsonTypeFormat? format;
+
+  @override
+  JsonStringType withNullability(bool isNullable) {
+    return JsonStringType(
+      isNullable: isNullable,
+      format: format,
+      extensions: extensions,
+    );
+  }
+}
+
+final class JsonNullType extends JsonTypeSchema {
+  const JsonNullType._() : super(isNullable: true);
+
+  static const JsonNullType instance = JsonNullType._();
+
+  @override
+  JsonNullType withNullability(bool isNullable) {
+    // always nullable
+    return this;
+  }
+}
+
+// additionalProperties = false
+final class JsonEmptyType extends JsonTypeSchema {
+  const JsonEmptyType._() : super(isNullable: false);
+
+  static const JsonEmptyType instance = JsonEmptyType._();
+
+  @override
+  JsonEmptyType withNullability(bool isNullable) {
+    // always non-nullable
+    return this;
+  }
+}
+
+// additionalProperties = true
+final class JsonAnyType extends JsonTypeSchema {
+  const JsonAnyType._() : super(isNullable: true);
+
+  static const JsonAnyType instance = JsonAnyType._();
+
+  @override
+  JsonAnyType withNullability(bool isNullable) {
+    // always nullable
+    return this;
+  }
+}
+
+// properties is! empty
+// presence of additional properties will create a colocated [JsonRecordType]... or make the class implement Map
+final class JsonObjectType extends JsonTypeSchema {
+  const JsonObjectType({
+    required super.isNullable,
+    required this.required,
+    required this.properties,
+    required this.additionalProperties,
+    super.extensions,
+  });
+
+  final Set<String> required;
+  final Map<String, JsonTypeSchema> properties;
+  final JsonTypeSchema? additionalProperties;
+
+  @override
+  JsonObjectType withNullability(bool isNullable) {
+    return JsonObjectType(
+      isNullable: isNullable,
+      properties: properties,
+      additionalProperties: additionalProperties,
+      required: required,
+      extensions: extensions,
+    );
+  }
+}
+
+// properties is empty
+// addiitonalProperties is! empty
+final class JsonRecordType extends JsonTypeSchema {
+  const JsonRecordType({
+    required super.isNullable,
+    required this.additionalProperties,
+    super.extensions,
+  });
+
+  final JsonTypeSchema additionalProperties;
+
+  @override
+  JsonRecordType withNullability(bool isNullable) {
+    return JsonRecordType(
+      isNullable: isNullable,
+      additionalProperties: additionalProperties,
+      extensions: extensions,
+    );
+  }
+}
+
+final class JsonArrayType extends JsonTypeSchema {
+  const JsonArrayType({
+    required super.isNullable,
+    required this.items,
+    required this.uniqueItems,
+    super.extensions,
+  });
+
+  final JsonTypeSchema items;
+  final bool uniqueItems;
+
+  @override
+  JsonArrayType withNullability(bool isNullable) {
+    return JsonArrayType(
+      isNullable: isNullable,
+      items: items,
+      uniqueItems: uniqueItems,
+      extensions: extensions,
+    );
+  }
+}
+
+final class JsonSingleValueType extends JsonTypeSchema {
+  JsonSingleValueType({
+    required this.value,
+    required this.type,
+    super.extensions,
+  }) : super(isNullable: type.isNullable);
+
+  final Object? value; // TODO(dnys1): dartgen constant value?
+  final JsonTypeSchema type;
+
+  @override
+  JsonSingleValueType withNullability(bool isNullable) {
+    return JsonSingleValueType(
+      value: value, // assert conforms
+      type: type.withNullability(isNullable),
+      extensions: extensions,
+    );
+  }
+}
+
+final class JsonEnumType extends JsonTypeSchema {
+  JsonEnumType({
+    required super.isNullable,
+    required this.values,
+    super.extensions,
+  }) : assert(values.isNotEmpty, 'Must have at least one value');
+
+  final List<String?> values;
+
+  @override
+  JsonEnumType withNullability(bool isNullable) {
+    return JsonEnumType(
+      isNullable: isNullable,
+      values: values,
+      extensions: extensions,
+    );
+  }
+}
+
+// anyOf
+final class JsonSumType extends JsonTypeSchema {
+  JsonSumType({
+    required super.isNullable,
+    required this.types,
+    super.extensions,
+  }) : assert(types.isNotEmpty, 'Must have at least one type');
+
+  final List<JsonTypeSchema> types;
+
+  @override
+  JsonSumType withNullability(bool isNullable) {
+    return JsonSumType(
+      isNullable: isNullable,
+      types: types,
+      extensions: extensions,
+    );
+  }
+}
+
+// allOf
+final class JsonProductType extends JsonTypeSchema {
+  JsonProductType({
+    required super.isNullable,
+    required this.types,
+    super.extensions,
+  }) : assert(types.isNotEmpty, 'Must have at least one type');
+
+  final List<JsonTypeSchema> types;
+
+  @override
+  JsonProductType withNullability(bool isNullable) {
+    return JsonProductType(
+      isNullable: isNullable,
+      types: types,
+      extensions: extensions,
+    );
+  }
+}
+
+// oneOf
+final class JsonSealedType extends JsonTypeSchema {
+  JsonSealedType({
+    required super.isNullable,
+    required this.types,
+    super.extensions,
+  }) : assert(types.isNotEmpty, 'Must have at least one type');
+
+  final List<JsonTypeSchema> types;
+
+  @override
+  JsonSealedType withNullability(bool isNullable) {
+    return JsonSealedType(
+      isNullable: isNullable,
+      types: types,
+      extensions: extensions,
+    );
+  }
+}

--- a/apps/cli/test/openapi/fixtures/bookstore_v3.json
+++ b/apps/cli/test/openapi/fixtures/bookstore_v3.json
@@ -1,0 +1,392 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Bookstore",
+    "description": "A simple Bookstore API example.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://generated-bookstore.appspot.com/"
+    }
+  ],
+  "paths": {
+    "/shelves": {
+      "get": {
+        "description": "Return all shelves in the bookstore.",
+        "operationId": "listShelves",
+        "responses": {
+          "200": {
+            "description": "List of shelves in the bookstore.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/listShelvesResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new shelf in the bookstore.",
+        "operationId": "createShelf",
+        "requestBody": {
+          "description": "A shelf resource to create.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/shelf"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A newly created shelf resource.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shelf"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete all shelves.",
+        "operationId": "deleteShelves",
+        "responses": {
+          "default": {
+            "description": "An empty response body."
+          }
+        }
+      }
+    },
+    "/shelves/{shelf}": {
+      "get": {
+        "description": "Get a single shelf resource with the given ID.",
+        "operationId": "getShelf",
+        "parameters": [
+          {
+            "name": "shelf",
+            "in": "path",
+            "description": "ID of the shelf to get.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "A shelf resource.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shelf"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a single shelf with the given ID.",
+        "operationId": "deleteShelf",
+        "parameters": [
+          {
+            "name": "shelf",
+            "in": "path",
+            "description": "ID of the shelf to delete.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "An empty response body."
+          }
+        }
+      }
+    },
+    "/shelves/{shelf}/books": {
+      "get": {
+        "description": "Return all books in a shelf with the given ID.",
+        "operationId": "listBooks",
+        "parameters": [
+          {
+            "name": "shelf",
+            "in": "path",
+            "description": "ID of the shelf whose books should be returned.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "List of books on the specified shelf.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/listBooksResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new book on the shelf.",
+        "operationId": "createBook",
+        "parameters": [
+          {
+            "name": "shelf",
+            "in": "path",
+            "description": "ID of the shelf where the book should be created.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Book to create.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/book"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "A newly created book resource.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/book"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shelves/{shelf}/books/{book}": {
+      "get": {
+        "description": "Get a single book with a given ID from a shelf.",
+        "operationId": "getBook",
+        "parameters": [
+          {
+            "name": "shelf",
+            "in": "path",
+            "description": "ID of the shelf from which to get the book.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "description": "ID of the book to get from the shelf.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "A book resource.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/book"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a single book with a given ID from a shelf.",
+        "operationId": "deleteBook",
+        "parameters": [
+          {
+            "name": "shelf",
+            "in": "path",
+            "description": "ID of the shelf from which to delete the book.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "description": "ID of the book to delete from the shelf.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "An empty response body."
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "book": {
+        "required": [
+          "name",
+          "author",
+          "title"
+        ],
+        "type": "object",
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "listBooksResponse": {
+        "required": [
+          "books"
+        ],
+        "type": "object",
+        "properties": {
+          "books": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/book"
+            }
+          }
+        }
+      },
+      "listShelvesResponse": {
+        "type": "object",
+        "properties": {
+          "shelves": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/shelf"
+            }
+          }
+        }
+      },
+      "shelf": {
+        "required": [
+          "name",
+          "theme"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "theme": {
+            "type": "string"
+          }
+        }
+      },
+      "error": {
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "key",
+        "in": "query"
+      }
+    }
+  },
+  "security": [
+    {
+      "api_key": [
+      ]
+    }
+  ]
+}

--- a/apps/cli/test/openapi/fixtures/bookstore_v3.spec
+++ b/apps/cli/test/openapi/fixtures/bookstore_v3.spec
@@ -1,0 +1,738 @@
+OpenApiDocument {
+  version=3.0.0,
+  info=OpenApiInfo {
+    title=Bookstore,
+    description=A simple Bookstore API example.,
+    apiVersion=1.0.0,
+    ref=#/info,
+    node={title: Bookstore, description: A simple Bookstore API example., version: 1.0.0},
+  },
+  servers=[OpenApiServer {
+    url=https://generated-bookstore.appspot.com/,
+    variables={},
+    ref=#/servers/0,
+    node={url: https://generated-bookstore.appspot.com/},
+  }],
+  paths={/shelves: OpenApiComponentOrRef {
+    ref=#/paths//shelves,
+    component=OpenApiPathItem {
+      operations={get: OpenApiOperation {
+        type=get,
+        tags=[],
+        description=Return all shelves in the bookstore.,
+        operationId=listShelves,
+        parameters=[],
+        responses={200: OpenApiComponentOrRef {
+          ref=#/paths//shelves/get/responses/200,
+          component=OpenApiResponse {
+            description=List of shelves in the bookstore.,
+            headers={},
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/get/responses/200/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/listShelvesResponse,
+                  name=listShelvesResponse,
+                  node={$ref: #/components/schemas/listShelvesResponse},
+                },
+                node={$ref: #/components/schemas/listShelvesResponse},
+              },
+              encoding={},
+              ref=#/paths//shelves/get/responses/200/content/application/json,
+              node={schema: {$ref: #/components/schemas/listShelvesResponse}},
+            }},
+            ref=#/paths//shelves/get/responses/200,
+            node={description: List of shelves in the bookstore., content: {application/json: {schema: {$ref: #/components/schemas/listShelvesResponse}}}},
+          },
+        }},
+        deprecated=false,
+      }, post: OpenApiOperation {
+        type=post,
+        tags=[],
+        description=Create a new shelf in the bookstore.,
+        operationId=createShelf,
+        parameters=[],
+        requestBody=OpenApiComponentOrRef {
+          ref=#/paths//shelves/post/requestBody,
+          component=OpenApiRequestBody {
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/post/requestBody/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/shelf,
+                  name=shelf,
+                  node={$ref: #/components/schemas/shelf},
+                },
+                node={$ref: #/components/schemas/shelf},
+              },
+              encoding={},
+              ref=#/paths//shelves/post/requestBody/content/application/json,
+              node={schema: {$ref: #/components/schemas/shelf}},
+            }},
+            description=A shelf resource to create.,
+            required=true,
+            ref=#/paths//shelves/post/requestBody,
+            node={description: A shelf resource to create., content: {application/json: {schema: {$ref: #/components/schemas/shelf}}}, required: true},
+          },
+        },
+        responses={200: OpenApiComponentOrRef {
+          ref=#/paths//shelves/post/responses/200,
+          component=OpenApiResponse {
+            description=A newly created shelf resource.,
+            headers={},
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/post/responses/200/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/shelf,
+                  name=shelf,
+                  node={$ref: #/components/schemas/shelf},
+                },
+                node={$ref: #/components/schemas/shelf},
+              },
+              encoding={},
+              ref=#/paths//shelves/post/responses/200/content/application/json,
+              node={schema: {$ref: #/components/schemas/shelf}},
+            }},
+            ref=#/paths//shelves/post/responses/200,
+            node={description: A newly created shelf resource., content: {application/json: {schema: {$ref: #/components/schemas/shelf}}}},
+          },
+        }},
+        deprecated=false,
+      }, delete: OpenApiOperation {
+        type=delete,
+        tags=[],
+        description=Delete all shelves.,
+        operationId=deleteShelves,
+        parameters=[],
+        responses={},
+        defaultResponse=OpenApiComponentOrRef {
+          ref=#/paths//shelves/delete/responses/default,
+          component=OpenApiResponse {
+            description=An empty response body.,
+            headers={},
+            content={},
+            ref=#/paths//shelves/delete/responses/default,
+            node={description: An empty response body.},
+          },
+        },
+        deprecated=false,
+      }},
+      parameters=[],
+      ref=#/paths//shelves,
+      node={get: {description: Return all shelves in the bookstore., operationId: listShelves, responses: {200: {description: List of shelves in the bookstore., content: {application/json: {schema: {$ref: #/components/schemas/listShelvesResponse}}}}}}, post: {description: Create a new shelf in the bookstore., operationId: createShelf, requestBody: {description: A shelf resource to create., content: {application/json: {schema: {$ref: #/components/schemas/shelf}}}, required: true}, responses: {200: {description: A newly created shelf resource., content: {application/json: {schema: {$ref: #/components/schemas/shelf}}}}}}, delete: {description: Delete all shelves., operationId: deleteShelves, responses: {default: {description: An empty response body.}}}},
+    },
+  }, /shelves/{shelf}: OpenApiComponentOrRef {
+    ref=#/paths//shelves/{shelf},
+    component=OpenApiPathItem {
+      operations={get: OpenApiOperation {
+        type=get,
+        tags=[],
+        description=Get a single shelf resource with the given ID.,
+        operationId=getShelf,
+        parameters=[OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/get/parameters/0,
+          component=OpenApiParameter {
+            name=shelf,
+            location=path,
+            description=ID of the shelf to get.,
+            required=true,
+            deprecated=false,
+            allowEmptyValue=false,
+            schema=OpenApiComponentOrRef {
+              ref=#/paths//shelves/{shelf}/get/parameters/0/schema,
+              component=OpenApiSchema {
+                type=integer,
+                format=int64,
+                ref=#/paths//shelves/{shelf}/get/parameters/0/schema,
+                node={type: integer, format: int64},
+              },
+            },
+            ref=#/paths//shelves/{shelf}/get/parameters/0,
+            node={name: shelf, in: path, description: ID of the shelf to get., required: true, schema: {type: integer, format: int64}},
+          },
+        }],
+        responses={200: OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/get/responses/200,
+          component=OpenApiResponse {
+            description=A shelf resource.,
+            headers={},
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/{shelf}/get/responses/200/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/shelf,
+                  name=shelf,
+                  node={$ref: #/components/schemas/shelf},
+                },
+                node={$ref: #/components/schemas/shelf},
+              },
+              encoding={},
+              ref=#/paths//shelves/{shelf}/get/responses/200/content/application/json,
+              node={schema: {$ref: #/components/schemas/shelf}},
+            }},
+            ref=#/paths//shelves/{shelf}/get/responses/200,
+            node={description: A shelf resource., content: {application/json: {schema: {$ref: #/components/schemas/shelf}}}},
+          },
+        }},
+        defaultResponse=OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/get/responses/default,
+          component=OpenApiResponse {
+            description=unexpected error,
+            headers={},
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/{shelf}/get/responses/default/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/error,
+                  name=error,
+                  node={$ref: #/components/schemas/error},
+                },
+                node={$ref: #/components/schemas/error},
+              },
+              encoding={},
+              ref=#/paths//shelves/{shelf}/get/responses/default/content/application/json,
+              node={schema: {$ref: #/components/schemas/error}},
+            }},
+            ref=#/paths//shelves/{shelf}/get/responses/default,
+            node={description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}},
+          },
+        },
+        deprecated=false,
+      }, delete: OpenApiOperation {
+        type=delete,
+        tags=[],
+        description=Delete a single shelf with the given ID.,
+        operationId=deleteShelf,
+        parameters=[OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/delete/parameters/0,
+          component=OpenApiParameter {
+            name=shelf,
+            location=path,
+            description=ID of the shelf to delete.,
+            required=true,
+            deprecated=false,
+            allowEmptyValue=false,
+            schema=OpenApiComponentOrRef {
+              ref=#/paths//shelves/{shelf}/delete/parameters/0/schema,
+              component=OpenApiSchema {
+                type=integer,
+                format=int64,
+                ref=#/paths//shelves/{shelf}/delete/parameters/0/schema,
+                node={type: integer, format: int64},
+              },
+            },
+            ref=#/paths//shelves/{shelf}/delete/parameters/0,
+            node={name: shelf, in: path, description: ID of the shelf to delete., required: true, schema: {type: integer, format: int64}},
+          },
+        }],
+        responses={},
+        defaultResponse=OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/delete/responses/default,
+          component=OpenApiResponse {
+            description=An empty response body.,
+            headers={},
+            content={},
+            ref=#/paths//shelves/{shelf}/delete/responses/default,
+            node={description: An empty response body.},
+          },
+        },
+        deprecated=false,
+      }},
+      parameters=[],
+      ref=#/paths//shelves/{shelf},
+      node={get: {description: Get a single shelf resource with the given ID., operationId: getShelf, parameters: [{name: shelf, in: path, description: ID of the shelf to get., required: true, schema: {type: integer, format: int64}}], responses: {default: {description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}}, 200: {description: A shelf resource., content: {application/json: {schema: {$ref: #/components/schemas/shelf}}}}}}, delete: {description: Delete a single shelf with the given ID., operationId: deleteShelf, parameters: [{name: shelf, in: path, description: ID of the shelf to delete., required: true, schema: {type: integer, format: int64}}], responses: {default: {description: An empty response body.}}}},
+    },
+  }, /shelves/{shelf}/books: OpenApiComponentOrRef {
+    ref=#/paths//shelves/{shelf}/books,
+    component=OpenApiPathItem {
+      operations={get: OpenApiOperation {
+        type=get,
+        tags=[],
+        description=Return all books in a shelf with the given ID.,
+        operationId=listBooks,
+        parameters=[OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/get/parameters/0,
+          component=OpenApiParameter {
+            name=shelf,
+            location=path,
+            description=ID of the shelf whose books should be returned.,
+            required=true,
+            deprecated=false,
+            allowEmptyValue=false,
+            schema=OpenApiComponentOrRef {
+              ref=#/paths//shelves/{shelf}/books/get/parameters/0/schema,
+              component=OpenApiSchema {
+                type=integer,
+                format=int64,
+                ref=#/paths//shelves/{shelf}/books/get/parameters/0/schema,
+                node={type: integer, format: int64},
+              },
+            },
+            ref=#/paths//shelves/{shelf}/books/get/parameters/0,
+            node={name: shelf, in: path, description: ID of the shelf whose books should be returned., required: true, schema: {type: integer, format: int64}},
+          },
+        }],
+        responses={200: OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/get/responses/200,
+          component=OpenApiResponse {
+            description=List of books on the specified shelf.,
+            headers={},
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/{shelf}/books/get/responses/200/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/listBooksResponse,
+                  name=listBooksResponse,
+                  node={$ref: #/components/schemas/listBooksResponse},
+                },
+                node={$ref: #/components/schemas/listBooksResponse},
+              },
+              encoding={},
+              ref=#/paths//shelves/{shelf}/books/get/responses/200/content/application/json,
+              node={schema: {$ref: #/components/schemas/listBooksResponse}},
+            }},
+            ref=#/paths//shelves/{shelf}/books/get/responses/200,
+            node={description: List of books on the specified shelf., content: {application/json: {schema: {$ref: #/components/schemas/listBooksResponse}}}},
+          },
+        }},
+        defaultResponse=OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/get/responses/default,
+          component=OpenApiResponse {
+            description=unexpected error,
+            headers={},
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/{shelf}/books/get/responses/default/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/error,
+                  name=error,
+                  node={$ref: #/components/schemas/error},
+                },
+                node={$ref: #/components/schemas/error},
+              },
+              encoding={},
+              ref=#/paths//shelves/{shelf}/books/get/responses/default/content/application/json,
+              node={schema: {$ref: #/components/schemas/error}},
+            }},
+            ref=#/paths//shelves/{shelf}/books/get/responses/default,
+            node={description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}},
+          },
+        },
+        deprecated=false,
+      }, post: OpenApiOperation {
+        type=post,
+        tags=[],
+        description=Create a new book on the shelf.,
+        operationId=createBook,
+        parameters=[OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/post/parameters/0,
+          component=OpenApiParameter {
+            name=shelf,
+            location=path,
+            description=ID of the shelf where the book should be created.,
+            required=true,
+            deprecated=false,
+            allowEmptyValue=false,
+            schema=OpenApiComponentOrRef {
+              ref=#/paths//shelves/{shelf}/books/post/parameters/0/schema,
+              component=OpenApiSchema {
+                type=integer,
+                format=int64,
+                ref=#/paths//shelves/{shelf}/books/post/parameters/0/schema,
+                node={type: integer, format: int64},
+              },
+            },
+            ref=#/paths//shelves/{shelf}/books/post/parameters/0,
+            node={name: shelf, in: path, description: ID of the shelf where the book should be created., required: true, schema: {type: integer, format: int64}},
+          },
+        }],
+        requestBody=OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/post/requestBody,
+          component=OpenApiRequestBody {
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/{shelf}/books/post/requestBody/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/book,
+                  name=book,
+                  node={$ref: #/components/schemas/book},
+                },
+                node={$ref: #/components/schemas/book},
+              },
+              encoding={},
+              ref=#/paths//shelves/{shelf}/books/post/requestBody/content/application/json,
+              node={schema: {$ref: #/components/schemas/book}},
+            }},
+            description=Book to create.,
+            required=true,
+            ref=#/paths//shelves/{shelf}/books/post/requestBody,
+            node={description: Book to create., content: {application/json: {schema: {$ref: #/components/schemas/book}}}, required: true},
+          },
+        },
+        responses={200: OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/post/responses/200,
+          component=OpenApiResponse {
+            description=A newly created book resource.,
+            headers={},
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/{shelf}/books/post/responses/200/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/book,
+                  name=book,
+                  node={$ref: #/components/schemas/book},
+                },
+                node={$ref: #/components/schemas/book},
+              },
+              encoding={},
+              ref=#/paths//shelves/{shelf}/books/post/responses/200/content/application/json,
+              node={schema: {$ref: #/components/schemas/book}},
+            }},
+            ref=#/paths//shelves/{shelf}/books/post/responses/200,
+            node={description: A newly created book resource., content: {application/json: {schema: {$ref: #/components/schemas/book}}}},
+          },
+        }},
+        defaultResponse=OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/post/responses/default,
+          component=OpenApiResponse {
+            description=unexpected error,
+            headers={},
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/{shelf}/books/post/responses/default/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/error,
+                  name=error,
+                  node={$ref: #/components/schemas/error},
+                },
+                node={$ref: #/components/schemas/error},
+              },
+              encoding={},
+              ref=#/paths//shelves/{shelf}/books/post/responses/default/content/application/json,
+              node={schema: {$ref: #/components/schemas/error}},
+            }},
+            ref=#/paths//shelves/{shelf}/books/post/responses/default,
+            node={description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}},
+          },
+        },
+        deprecated=false,
+      }},
+      parameters=[],
+      ref=#/paths//shelves/{shelf}/books,
+      node={get: {description: Return all books in a shelf with the given ID., operationId: listBooks, parameters: [{name: shelf, in: path, description: ID of the shelf whose books should be returned., required: true, schema: {type: integer, format: int64}}], responses: {default: {description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}}, 200: {description: List of books on the specified shelf., content: {application/json: {schema: {$ref: #/components/schemas/listBooksResponse}}}}}}, post: {description: Create a new book on the shelf., operationId: createBook, parameters: [{name: shelf, in: path, description: ID of the shelf where the book should be created., required: true, schema: {type: integer, format: int64}}], requestBody: {description: Book to create., content: {application/json: {schema: {$ref: #/components/schemas/book}}}, required: true}, responses: {default: {description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}}, 200: {description: A newly created book resource., content: {application/json: {schema: {$ref: #/components/schemas/book}}}}}}},
+    },
+  }, /shelves/{shelf}/books/{book}: OpenApiComponentOrRef {
+    ref=#/paths//shelves/{shelf}/books/{book},
+    component=OpenApiPathItem {
+      operations={get: OpenApiOperation {
+        type=get,
+        tags=[],
+        description=Get a single book with a given ID from a shelf.,
+        operationId=getBook,
+        parameters=[OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/{book}/get/parameters/0,
+          component=OpenApiParameter {
+            name=shelf,
+            location=path,
+            description=ID of the shelf from which to get the book.,
+            required=true,
+            deprecated=false,
+            allowEmptyValue=false,
+            schema=OpenApiComponentOrRef {
+              ref=#/paths//shelves/{shelf}/books/{book}/get/parameters/0/schema,
+              component=OpenApiSchema {
+                type=integer,
+                format=int64,
+                ref=#/paths//shelves/{shelf}/books/{book}/get/parameters/0/schema,
+                node={type: integer, format: int64},
+              },
+            },
+            ref=#/paths//shelves/{shelf}/books/{book}/get/parameters/0,
+            node={name: shelf, in: path, description: ID of the shelf from which to get the book., required: true, schema: {type: integer, format: int64}},
+          },
+        }, OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/{book}/get/parameters/1,
+          component=OpenApiParameter {
+            name=book,
+            location=path,
+            description=ID of the book to get from the shelf.,
+            required=true,
+            deprecated=false,
+            allowEmptyValue=false,
+            schema=OpenApiComponentOrRef {
+              ref=#/paths//shelves/{shelf}/books/{book}/get/parameters/1/schema,
+              component=OpenApiSchema {
+                type=integer,
+                format=int64,
+                ref=#/paths//shelves/{shelf}/books/{book}/get/parameters/1/schema,
+                node={type: integer, format: int64},
+              },
+            },
+            ref=#/paths//shelves/{shelf}/books/{book}/get/parameters/1,
+            node={name: book, in: path, description: ID of the book to get from the shelf., required: true, schema: {type: integer, format: int64}},
+          },
+        }],
+        responses={200: OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/{book}/get/responses/200,
+          component=OpenApiResponse {
+            description=A book resource.,
+            headers={},
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/{shelf}/books/{book}/get/responses/200/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/book,
+                  name=book,
+                  node={$ref: #/components/schemas/book},
+                },
+                node={$ref: #/components/schemas/book},
+              },
+              encoding={},
+              ref=#/paths//shelves/{shelf}/books/{book}/get/responses/200/content/application/json,
+              node={schema: {$ref: #/components/schemas/book}},
+            }},
+            ref=#/paths//shelves/{shelf}/books/{book}/get/responses/200,
+            node={description: A book resource., content: {application/json: {schema: {$ref: #/components/schemas/book}}}},
+          },
+        }},
+        defaultResponse=OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/{book}/get/responses/default,
+          component=OpenApiResponse {
+            description=unexpected error,
+            headers={},
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//shelves/{shelf}/books/{book}/get/responses/default/content/application/json/schema,
+                reference=OpenApiSchemaReference {
+                  ref=#/components/schemas/error,
+                  name=error,
+                  node={$ref: #/components/schemas/error},
+                },
+                node={$ref: #/components/schemas/error},
+              },
+              encoding={},
+              ref=#/paths//shelves/{shelf}/books/{book}/get/responses/default/content/application/json,
+              node={schema: {$ref: #/components/schemas/error}},
+            }},
+            ref=#/paths//shelves/{shelf}/books/{book}/get/responses/default,
+            node={description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}},
+          },
+        },
+        deprecated=false,
+      }, delete: OpenApiOperation {
+        type=delete,
+        tags=[],
+        description=Delete a single book with a given ID from a shelf.,
+        operationId=deleteBook,
+        parameters=[OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/{book}/delete/parameters/0,
+          component=OpenApiParameter {
+            name=shelf,
+            location=path,
+            description=ID of the shelf from which to delete the book.,
+            required=true,
+            deprecated=false,
+            allowEmptyValue=false,
+            schema=OpenApiComponentOrRef {
+              ref=#/paths//shelves/{shelf}/books/{book}/delete/parameters/0/schema,
+              component=OpenApiSchema {
+                type=integer,
+                format=int64,
+                ref=#/paths//shelves/{shelf}/books/{book}/delete/parameters/0/schema,
+                node={type: integer, format: int64},
+              },
+            },
+            ref=#/paths//shelves/{shelf}/books/{book}/delete/parameters/0,
+            node={name: shelf, in: path, description: ID of the shelf from which to delete the book., required: true, schema: {type: integer, format: int64}},
+          },
+        }, OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/{book}/delete/parameters/1,
+          component=OpenApiParameter {
+            name=book,
+            location=path,
+            description=ID of the book to delete from the shelf.,
+            required=true,
+            deprecated=false,
+            allowEmptyValue=false,
+            schema=OpenApiComponentOrRef {
+              ref=#/paths//shelves/{shelf}/books/{book}/delete/parameters/1/schema,
+              component=OpenApiSchema {
+                type=integer,
+                format=int64,
+                ref=#/paths//shelves/{shelf}/books/{book}/delete/parameters/1/schema,
+                node={type: integer, format: int64},
+              },
+            },
+            ref=#/paths//shelves/{shelf}/books/{book}/delete/parameters/1,
+            node={name: book, in: path, description: ID of the book to delete from the shelf., required: true, schema: {type: integer, format: int64}},
+          },
+        }],
+        responses={},
+        defaultResponse=OpenApiComponentOrRef {
+          ref=#/paths//shelves/{shelf}/books/{book}/delete/responses/default,
+          component=OpenApiResponse {
+            description=An empty response body.,
+            headers={},
+            content={},
+            ref=#/paths//shelves/{shelf}/books/{book}/delete/responses/default,
+            node={description: An empty response body.},
+          },
+        },
+        deprecated=false,
+      }},
+      parameters=[],
+      ref=#/paths//shelves/{shelf}/books/{book},
+      node={get: {description: Get a single book with a given ID from a shelf., operationId: getBook, parameters: [{name: shelf, in: path, description: ID of the shelf from which to get the book., required: true, schema: {type: integer, format: int64}}, {name: book, in: path, description: ID of the book to get from the shelf., required: true, schema: {type: integer, format: int64}}], responses: {default: {description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}}, 200: {description: A book resource., content: {application/json: {schema: {$ref: #/components/schemas/book}}}}}}, delete: {description: Delete a single book with a given ID from a shelf., operationId: deleteBook, parameters: [{name: shelf, in: path, description: ID of the shelf from which to delete the book., required: true, schema: {type: integer, format: int64}}, {name: book, in: path, description: ID of the book to delete from the shelf., required: true, schema: {type: integer, format: int64}}], responses: {default: {description: An empty response body.}}}},
+    },
+  }},
+  components=OpenApiComponents {
+    schemas={book: OpenApiSchema {
+      name=book,
+      type=object,
+      properties={author: OpenApiComponentOrRef {
+        ref=#/components/schemas/book/properties/author,
+        component=OpenApiSchema {
+          name=author,
+          type=string,
+          ref=#/components/schemas/book/properties/author,
+          node={type: string},
+        },
+      }, name: OpenApiComponentOrRef {
+        ref=#/components/schemas/book/properties/name,
+        component=OpenApiSchema {
+          name=name,
+          type=string,
+          ref=#/components/schemas/book/properties/name,
+          node={type: string},
+        },
+      }, title: OpenApiComponentOrRef {
+        ref=#/components/schemas/book/properties/title,
+        component=OpenApiSchema {
+          name=title,
+          type=string,
+          ref=#/components/schemas/book/properties/title,
+          node={type: string},
+        },
+      }},
+      required={name, author, title},
+      ref=#/components/schemas/book,
+      node={required: [name, author, title], type: object, properties: {author: {type: string}, name: {type: string}, title: {type: string}}},
+    }, listBooksResponse: OpenApiSchema {
+      name=listBooksResponse,
+      type=object,
+      properties={books: OpenApiComponentOrRef {
+        ref=#/components/schemas/listBooksResponse/properties/books,
+        component=OpenApiSchema {
+          name=books,
+          type=array,
+          items=OpenApiComponentOrRef {
+            ref=#/components/schemas/listBooksResponse/properties/books/items,
+            reference=OpenApiSchemaReference {
+              ref=#/components/schemas/book,
+              name=book,
+              node={$ref: #/components/schemas/book},
+            },
+            node={$ref: #/components/schemas/book},
+          },
+          ref=#/components/schemas/listBooksResponse/properties/books,
+          node={type: array, items: {$ref: #/components/schemas/book}},
+        },
+      }},
+      required={books},
+      ref=#/components/schemas/listBooksResponse,
+      node={required: [books], type: object, properties: {books: {type: array, items: {$ref: #/components/schemas/book}}}},
+    }, listShelvesResponse: OpenApiSchema {
+      name=listShelvesResponse,
+      type=object,
+      properties={shelves: OpenApiComponentOrRef {
+        ref=#/components/schemas/listShelvesResponse/properties/shelves,
+        component=OpenApiSchema {
+          name=shelves,
+          type=array,
+          items=OpenApiComponentOrRef {
+            ref=#/components/schemas/listShelvesResponse/properties/shelves/items,
+            reference=OpenApiSchemaReference {
+              ref=#/components/schemas/shelf,
+              name=shelf,
+              node={$ref: #/components/schemas/shelf},
+            },
+            node={$ref: #/components/schemas/shelf},
+          },
+          ref=#/components/schemas/listShelvesResponse/properties/shelves,
+          node={type: array, items: {$ref: #/components/schemas/shelf}},
+        },
+      }},
+      ref=#/components/schemas/listShelvesResponse,
+      node={type: object, properties: {shelves: {type: array, items: {$ref: #/components/schemas/shelf}}}},
+    }, shelf: OpenApiSchema {
+      name=shelf,
+      type=object,
+      properties={name: OpenApiComponentOrRef {
+        ref=#/components/schemas/shelf/properties/name,
+        component=OpenApiSchema {
+          name=name,
+          type=string,
+          ref=#/components/schemas/shelf/properties/name,
+          node={type: string},
+        },
+      }, theme: OpenApiComponentOrRef {
+        ref=#/components/schemas/shelf/properties/theme,
+        component=OpenApiSchema {
+          name=theme,
+          type=string,
+          ref=#/components/schemas/shelf/properties/theme,
+          node={type: string},
+        },
+      }},
+      required={name, theme},
+      ref=#/components/schemas/shelf,
+      node={required: [name, theme], type: object, properties: {name: {type: string}, theme: {type: string}}},
+    }, error: OpenApiSchema {
+      name=error,
+      type=object,
+      properties={code: OpenApiComponentOrRef {
+        ref=#/components/schemas/error/properties/code,
+        component=OpenApiSchema {
+          name=code,
+          type=integer,
+          format=int32,
+          ref=#/components/schemas/error/properties/code,
+          node={type: integer, format: int32},
+        },
+      }, message: OpenApiComponentOrRef {
+        ref=#/components/schemas/error/properties/message,
+        component=OpenApiSchema {
+          name=message,
+          type=string,
+          ref=#/components/schemas/error/properties/message,
+          node={type: string},
+        },
+      }},
+      required={code, message},
+      ref=#/components/schemas/error,
+      node={required: [code, message], type: object, properties: {code: {type: integer, format: int32}, message: {type: string}}},
+    }},
+    responses={},
+    parameters={},
+    requestBodies={},
+    headers={},
+    securitySchemes={api_key: OpenApiSecurityScheme {
+      type=apiKey,
+      name=key,
+      location=query,
+      ref=#/components/securitySchemes/api_key,
+      node={type: apiKey, name: key, in: query},
+    }},
+    paths={},
+    ref=#/components,
+    node={schemas: {book: {required: [name, author, title], type: object, properties: {author: {type: string}, name: {type: string}, title: {type: string}}}, listBooksResponse: {required: [books], type: object, properties: {books: {type: array, items: {$ref: #/components/schemas/book}}}}, listShelvesResponse: {type: object, properties: {shelves: {type: array, items: {$ref: #/components/schemas/shelf}}}}, shelf: {required: [name, theme], type: object, properties: {name: {type: string}, theme: {type: string}}}, error: {required: [code, message], type: object, properties: {code: {type: integer, format: int32}, message: {type: string}}}}, securitySchemes: {api_key: {type: apiKey, name: key, in: query}}},
+  },
+  securityRequirements=[OpenApiSecurityRequirement {
+    schemes={api_key: []},
+    ref=#/security/0,
+    node={api_key: []},
+  }],
+  ref=#,
+  node={openapi: 3.0.0, info: {title: Bookstore, description: A simple Bookstore API example., version: 1.0.0}, servers: [{url: https://generated-bookstore.appspot.com/}], paths: {/shelves: {get: {description: Return all shelves in the bookstore., operationId: listShelves, responses: {200: {description: List of shelves in the bookstore., content: {application/json: {schema: {$ref: #/components/schemas/listShelvesResponse}}}}}}, post: {description: Create a new shelf in the bookstore., operationId: createShelf, requestBody: {description: A shelf resource to create., content: {application/json: {schema: {$ref: #/components/schemas/shelf}}}, required: true}, responses: {200: {description: A newly created shelf resource., content: {application/json: {schema: {$ref: #/components/schemas/shelf}}}}}}, delete: {description: Delete all shelves., operationId: deleteShelves, responses: {default: {description: An empty response body.}}}}, /shelves/{shelf}: {get: {description: Get a single shelf resource with the given ID., operationId: getShelf, parameters: [{name: shelf, in: path, description: ID of the shelf to get., required: true, schema: {type: integer, format: int64}}], responses: {default: {description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}}, 200: {description: A shelf resource., content: {application/json: {schema: {$ref: #/components/schemas/shelf}}}}}}, delete: {description: Delete a single shelf with the given ID., operationId: deleteShelf, parameters: [{name: shelf, in: path, description: ID of the shelf to delete., required: true, schema: {type: integer, format: int64}}], responses: {default: {description: An empty response body.}}}}, /shelves/{shelf}/books: {get: {description: Return all books in a shelf with the given ID., operationId: listBooks, parameters: [{name: shelf, in: path, description: ID of the shelf whose books should be returned., required: true, schema: {type: integer, format: int64}}], responses: {default: {description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}}, 200: {description: List of books on the specified shelf., content: {application/json: {schema: {$ref: #/components/schemas/listBooksResponse}}}}}}, post: {description: Create a new book on the shelf., operationId: createBook, parameters: [{name: shelf, in: path, description: ID of the shelf where the book should be created., required: true, schema: {type: integer, format: int64}}], requestBody: {description: Book to create., content: {application/json: {schema: {$ref: #/components/schemas/book}}}, required: true}, responses: {default: {description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}}, 200: {description: A newly created book resource., content: {application/json: {schema: {$ref: #/components/schemas/book}}}}}}}, /shelves/{shelf}/books/{book}: {get: {description: Get a single book with a given ID from a shelf., operationId: getBook, parameters: [{name: shelf, in: path, description: ID of the shelf from which to get the book., required: true, schema: {type: integer, format: int64}}, {name: book, in: path, description: ID of the book to get from the shelf., required: true, schema: {type: integer, format: int64}}], responses: {default: {description: unexpected error, content: {application/json: {schema: {$ref: #/components/schemas/error}}}}, 200: {description: A book resource., content: {application/json: {schema: {$ref: #/components/schemas/book}}}}}}, delete: {description: Delete a single book with a given ID from a shelf., operationId: deleteBook, parameters: [{name: shelf, in: path, description: ID of the shelf from which to delete the book., required: true, schema: {type: integer, format: int64}}, {name: book, in: path, description: ID of the book to delete from the shelf., required: true, schema: {type: integer, format: int64}}], responses: {default: {description: An empty response body.}}}}}, components: {schemas: {book: {required: [name, author, title], type: object, properties: {author: {type: string}, name: {type: string}, title: {type: string}}}, listBooksResponse: {required: [books], type: object, properties: {books: {type: array, items: {$ref: #/components/schemas/book}}}}, listShelvesResponse: {type: object, properties: {shelves: {type: array, items: {$ref: #/components/schemas/shelf}}}}, shelf: {required: [name, theme], type: object, properties: {name: {type: string}, theme: {type: string}}}, error: {required: [code, message], type: object, properties: {code: {type: integer, format: int32}, message: {type: string}}}}, securitySchemes: {api_key: {type: apiKey, name: key, in: query}}}, security: [{api_key: []}]},
+}

--- a/apps/cli/test/openapi/fixtures/bookstore_v3.yaml
+++ b/apps/cli/test/openapi/fixtures/bookstore_v3.yaml
@@ -1,0 +1,282 @@
+openapi: '3.0.0'
+info:
+  title: Bookstore
+  description: |-
+      A simple Bookstore API example.
+  version: '1.0.0'
+servers:
+  - url: https://generated-bookstore.appspot.com/
+paths:
+  '/shelves':
+    get:
+      description: |-
+          Return all shelves in the bookstore.
+      operationId: listShelves
+      responses:
+        '200':
+          description: |-
+              List of shelves in the bookstore.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/listShelvesResponse'
+    post:
+      description: |-
+          Create a new shelf in the bookstore.
+      operationId: createShelf
+      requestBody:
+        description: |-
+            A shelf resource to create.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/shelf'
+        required: true
+      responses:
+        '200':
+          description: |-
+              A newly created shelf resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/shelf'
+    delete:
+      description: |-
+          Delete all shelves.
+      operationId: deleteShelves
+      responses:
+        default:
+          description: |-
+              An empty response body.
+  '/shelves/{shelf}':
+    get:
+      description: |-
+          Get a single shelf resource with the given ID.
+      operationId: getShelf
+      parameters:
+        - name: shelf
+          in: path
+          required: true
+          description: |-
+              ID of the shelf to get.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: |-
+              A shelf resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/shelf'
+        default:
+          description: |-
+              unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    delete:
+      description: |-
+          Delete a single shelf with the given ID.
+      operationId: deleteShelf
+      parameters:
+        - name: shelf
+          in: path
+          required: true
+          description: |-
+              ID of the shelf to delete.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        default:
+          description: |-
+              An empty response body.
+  '/shelves/{shelf}/books':
+    get:
+      description: |-
+          Return all books in a shelf with the given ID.
+      operationId: listBooks
+      parameters:
+        - name: shelf
+          in: path
+          required: true
+          description: |-
+              ID of the shelf whose books should be returned.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: |-
+              List of books on the specified shelf.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/listBooksResponse'
+        default:
+          description: |-
+              unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      description: |-
+          Create a new book on the shelf.
+      operationId: createBook
+      parameters:
+        - name: shelf
+          in: path
+          required: true
+          description: |-
+              ID of the shelf where the book should be created.
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        description: |-
+            Book to create.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/book'
+        required: true
+      responses:
+        '200':
+          description: |-
+              A newly created book resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/book'
+        default:
+          description: |-
+              unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+  '/shelves/{shelf}/books/{book}':
+    get:
+      description: |-
+          Get a single book with a given ID from a shelf.
+      operationId: getBook
+      parameters:
+        - name: shelf
+          in: path
+          required: true
+          description: |-
+              ID of the shelf from which to get the book.
+          schema:
+            type: integer
+            format: int64
+        - name: book
+          in: path
+          required: true
+          description: |-
+              ID of the book to get from the shelf.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: |-
+              A book resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/book'
+        default:
+          description: |-
+              unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    delete:
+      description: |-
+          Delete a single book with a given ID from a shelf.
+      operationId: deleteBook
+      parameters:
+        - name: shelf
+          in: path
+          required: true
+          description: |-
+              ID of the shelf from which to delete the book.
+          schema:
+            type: integer
+            format: int64
+        - name: book
+          in: path
+          required: true
+          description: |-
+              ID of the book to delete from the shelf.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        default:
+          description: |-
+              An empty response body.
+components:
+  schemas:
+    book:
+      type: object
+      properties:
+        author:
+          type: string
+        name:
+          type: string
+        title:
+          type: string
+      required:
+        - name
+        - author
+        - title
+    listBooksResponse:
+      type: object
+      properties:
+        books:
+          type: array
+          items:
+            $ref: '#/components/schemas/book'
+      required:
+        - books
+    listShelvesResponse:
+      type: object
+      properties:
+        shelves:
+          type: array
+          items:
+            $ref: '#/components/schemas/shelf'
+    shelf:
+      type: object
+      properties:
+        name:
+          type: string
+        theme:
+          type: string
+      required:
+        - name
+        - theme
+    error:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+      required:
+        - code
+        - message
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: key
+      in: query
+security:
+  - api_key:       []

--- a/apps/cli/test/openapi/fixtures/pet_discriminator_v3.json
+++ b/apps/cli/test/openapi/fixtures/pet_discriminator_v3.json
@@ -1,0 +1,97 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Petstore",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/pets": {
+            "patch": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Cat"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Dog"
+                                    }
+                                ],
+                                "discriminator": {
+                                    "propertyName": "pet_type"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Pet": {
+                "type": "object",
+                "required": [
+                    "pet_type"
+                ],
+                "properties": {
+                    "pet_type": {
+                        "type": "string"
+                    }
+                },
+                "discriminator": {
+                    "propertyName": "pet_type"
+                }
+            },
+            "Dog": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pet"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "bark": {
+                                "type": "boolean"
+                            },
+                            "breed": {
+                                "type": "string",
+                                "enum": [
+                                    "Dingo",
+                                    "Husky",
+                                    "Retriever",
+                                    "Shepherd"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            },
+            "Cat": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pet"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "hunts": {
+                                "type": "boolean"
+                            },
+                            "age": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/apps/cli/test/openapi/fixtures/pet_discriminator_v3.spec
+++ b/apps/cli/test/openapi/fixtures/pet_discriminator_v3.spec
@@ -1,0 +1,187 @@
+OpenApiDocument {
+  version=3.0.2,
+  info=OpenApiInfo {
+    title=Petstore,
+    apiVersion=1.0.0,
+    ref=#/info,
+    node={title: Petstore, version: 1.0.0},
+  },
+  servers=[],
+  paths={/pets: OpenApiComponentOrRef {
+    ref=#/paths//pets,
+    component=OpenApiPathItem {
+      operations={patch: OpenApiOperation {
+        type=patch,
+        tags=[],
+        parameters=[],
+        requestBody=OpenApiComponentOrRef {
+          ref=#/paths//pets/patch/requestBody,
+          component=OpenApiRequestBody {
+            content={application/json: OpenApiMediaType {
+              schema=OpenApiComponentOrRef {
+                ref=#/paths//pets/patch/requestBody/content/application/json/schema,
+                component=OpenApiSchema {
+                  oneOf=[OpenApiComponentOrRef {
+                    ref=#/paths//pets/patch/requestBody/content/application/json/schema/oneOf/0,
+                    reference=OpenApiSchemaReference {
+                      ref=#/components/schemas/Cat,
+                      name=Cat,
+                      node={$ref: #/components/schemas/Cat},
+                    },
+                    node={$ref: #/components/schemas/Cat},
+                  }, OpenApiComponentOrRef {
+                    ref=#/paths//pets/patch/requestBody/content/application/json/schema/oneOf/1,
+                    reference=OpenApiSchemaReference {
+                      ref=#/components/schemas/Dog,
+                      name=Dog,
+                      node={$ref: #/components/schemas/Dog},
+                    },
+                    node={$ref: #/components/schemas/Dog},
+                  }],
+                  discriminator=OpenApiDiscriminator {
+                    propertyName=pet_type,
+                    ref=#/paths//pets/patch/requestBody/content/application/json/schema/discriminator,
+                    node={propertyName: pet_type},
+                  },
+                  ref=#/paths//pets/patch/requestBody/content/application/json/schema,
+                  node={oneOf: [{$ref: #/components/schemas/Cat}, {$ref: #/components/schemas/Dog}], discriminator: {propertyName: pet_type}},
+                },
+              },
+              encoding={},
+              ref=#/paths//pets/patch/requestBody/content/application/json,
+              node={schema: {oneOf: [{$ref: #/components/schemas/Cat}, {$ref: #/components/schemas/Dog}], discriminator: {propertyName: pet_type}}},
+            }},
+            required=false,
+            ref=#/paths//pets/patch/requestBody,
+            node={content: {application/json: {schema: {oneOf: [{$ref: #/components/schemas/Cat}, {$ref: #/components/schemas/Dog}], discriminator: {propertyName: pet_type}}}}},
+          },
+        },
+        responses={200: OpenApiComponentOrRef {
+          ref=#/paths//pets/patch/responses/200,
+          component=OpenApiResponse {
+            description=Updated,
+            headers={},
+            content={},
+            ref=#/paths//pets/patch/responses/200,
+            node={description: Updated},
+          },
+        }},
+        deprecated=false,
+      }},
+      parameters=[],
+      ref=#/paths//pets,
+      node={patch: {requestBody: {content: {application/json: {schema: {oneOf: [{$ref: #/components/schemas/Cat}, {$ref: #/components/schemas/Dog}], discriminator: {propertyName: pet_type}}}}}, responses: {200: {description: Updated}}}},
+    },
+  }},
+  components=OpenApiComponents {
+    schemas={Pet: OpenApiSchema {
+      name=Pet,
+      type=object,
+      properties={pet_type: OpenApiComponentOrRef {
+        ref=#/components/schemas/Pet/properties/pet_type,
+        component=OpenApiSchema {
+          name=pet_type,
+          type=string,
+          ref=#/components/schemas/Pet/properties/pet_type,
+          node={type: string},
+        },
+      }},
+      required={pet_type},
+      discriminator=OpenApiDiscriminator {
+        propertyName=pet_type,
+        ref=#/components/schemas/Pet/discriminator,
+        node={propertyName: pet_type},
+      },
+      ref=#/components/schemas/Pet,
+      node={type: object, required: [pet_type], properties: {pet_type: {type: string}}, discriminator: {propertyName: pet_type}},
+    }, Dog: OpenApiSchema {
+      name=Dog,
+      allOf=[OpenApiComponentOrRef {
+        ref=#/components/schemas/Dog/allOf/0,
+        reference=OpenApiSchemaReference {
+          ref=#/components/schemas/Pet,
+          name=Pet,
+          node={$ref: #/components/schemas/Pet},
+        },
+        node={$ref: #/components/schemas/Pet},
+      }, OpenApiComponentOrRef {
+        ref=#/components/schemas/Dog/allOf/1,
+        component=OpenApiSchema {
+          name=1,
+          type=object,
+          properties={bark: OpenApiComponentOrRef {
+            ref=#/components/schemas/Dog/allOf/1/properties/bark,
+            component=OpenApiSchema {
+              name=bark,
+              type=boolean,
+              ref=#/components/schemas/Dog/allOf/1/properties/bark,
+              node={type: boolean},
+            },
+          }, breed: OpenApiComponentOrRef {
+            ref=#/components/schemas/Dog/allOf/1/properties/breed,
+            component=OpenApiSchema {
+              name=breed,
+              type=string,
+              enumValues={Dingo, Husky, Retriever, Shepherd},
+              ref=#/components/schemas/Dog/allOf/1/properties/breed,
+              node={type: string, enum: [Dingo, Husky, Retriever, Shepherd]},
+            },
+          }},
+          ref=#/components/schemas/Dog/allOf/1,
+          node={type: object, properties: {bark: {type: boolean}, breed: {type: string, enum: [Dingo, Husky, Retriever, Shepherd]}}},
+        },
+      }],
+      ref=#/components/schemas/Dog,
+      node={allOf: [{$ref: #/components/schemas/Pet}, {type: object, properties: {bark: {type: boolean}, breed: {type: string, enum: [Dingo, Husky, Retriever, Shepherd]}}}]},
+    }, Cat: OpenApiSchema {
+      name=Cat,
+      allOf=[OpenApiComponentOrRef {
+        ref=#/components/schemas/Cat/allOf/0,
+        reference=OpenApiSchemaReference {
+          ref=#/components/schemas/Pet,
+          name=Pet,
+          node={$ref: #/components/schemas/Pet},
+        },
+        node={$ref: #/components/schemas/Pet},
+      }, OpenApiComponentOrRef {
+        ref=#/components/schemas/Cat/allOf/1,
+        component=OpenApiSchema {
+          name=1,
+          type=object,
+          properties={hunts: OpenApiComponentOrRef {
+            ref=#/components/schemas/Cat/allOf/1/properties/hunts,
+            component=OpenApiSchema {
+              name=hunts,
+              type=boolean,
+              ref=#/components/schemas/Cat/allOf/1/properties/hunts,
+              node={type: boolean},
+            },
+          }, age: OpenApiComponentOrRef {
+            ref=#/components/schemas/Cat/allOf/1/properties/age,
+            component=OpenApiSchema {
+              name=age,
+              type=integer,
+              ref=#/components/schemas/Cat/allOf/1/properties/age,
+              node={type: integer},
+            },
+          }},
+          ref=#/components/schemas/Cat/allOf/1,
+          node={type: object, properties: {hunts: {type: boolean}, age: {type: integer}}},
+        },
+      }],
+      ref=#/components/schemas/Cat,
+      node={allOf: [{$ref: #/components/schemas/Pet}, {type: object, properties: {hunts: {type: boolean}, age: {type: integer}}}]},
+    }},
+    responses={},
+    parameters={},
+    requestBodies={},
+    headers={},
+    securitySchemes={},
+    paths={},
+    ref=#/components,
+    node={schemas: {Pet: {type: object, required: [pet_type], properties: {pet_type: {type: string}}, discriminator: {propertyName: pet_type}}, Dog: {allOf: [{$ref: #/components/schemas/Pet}, {type: object, properties: {bark: {type: boolean}, breed: {type: string, enum: [Dingo, Husky, Retriever, Shepherd]}}}]}, Cat: {allOf: [{$ref: #/components/schemas/Pet}, {type: object, properties: {hunts: {type: boolean}, age: {type: integer}}}]}}},
+  },
+  securityRequirements=[],
+  ref=#,
+  node={openapi: 3.0.2, info: {title: Petstore, version: 1.0.0}, paths: {/pets: {patch: {requestBody: {content: {application/json: {schema: {oneOf: [{$ref: #/components/schemas/Cat}, {$ref: #/components/schemas/Dog}], discriminator: {propertyName: pet_type}}}}}, responses: {200: {description: Updated}}}}}, components: {schemas: {Pet: {type: object, required: [pet_type], properties: {pet_type: {type: string}}, discriminator: {propertyName: pet_type}}, Dog: {allOf: [{$ref: #/components/schemas/Pet}, {type: object, properties: {bark: {type: boolean}, breed: {type: string, enum: [Dingo, Husky, Retriever, Shepherd]}}}]}, Cat: {allOf: [{$ref: #/components/schemas/Pet}, {type: object, properties: {hunts: {type: boolean}, age: {type: integer}}}]}}}},
+}

--- a/apps/cli/test/openapi/fixtures/pet_discriminator_v3.yaml
+++ b/apps/cli/test/openapi/fixtures/pet_discriminator_v3.yaml
@@ -1,0 +1,54 @@
+openapi: '3.0.2'
+info:
+  title: Petstore
+  version: '1.0.0'
+paths:
+  '/pets':
+    patch:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: pet_type
+      responses:
+        '200':
+          description: |-
+              Updated
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        pet_type:
+          type: string
+      required:
+        - pet_type
+      discriminator:
+        propertyName: pet_type
+    Dog:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            bark:
+              type: boolean
+            breed:
+              type: string
+              enum:
+                - Dingo
+                - Husky
+                - Retriever
+                - Shepherd
+    Cat:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            hunts:
+              type: boolean
+            age:
+              type: integer

--- a/apps/cli/test/openapi/openapi_test.dart
+++ b/apps/cli/test/openapi/openapi_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:celest_cli/src/context.dart';
+import 'package:celest_cli/src/openapi/loader/openapi_loader.dart';
+import 'package:celest_cli/src/openapi/renderer/openapi_renderer.dart';
+import 'package:test/test.dart';
+import 'package:yaml/src/equality.dart' as equality;
+import 'package:yaml/yaml.dart';
+
+void main() {
+  group('OpenAPI', () {
+    final fixturesDir =
+        Directory.current.uri.resolve('./test/openapi/fixtures');
+    final fixtureSpecs = Directory.fromUri(fixturesDir)
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.json'));
+
+    for (final fixtureSpec in fixtureSpecs) {
+      final basename = p.basename(fixtureSpec.path);
+      group(basename, () {
+        final fixtureSpecJson = fixtureSpec.readAsStringSync();
+
+        test('can load document', () {
+          expect(
+            () => loadOpenApiDocument(
+              fixtureSpecJson,
+              sourceUri: fixtureSpec.uri,
+            ),
+            returnsNormally,
+          );
+        });
+
+        test('can render to YAML', () {
+          final document = loadOpenApiDocument(
+            fixtureSpecJson,
+            sourceUri: fixtureSpec.uri,
+          );
+          final documentFile = File(p.setExtension(fixtureSpec.path, '.spec'));
+          documentFile.writeAsStringSync(document.toString());
+
+          final rendered = document.toYaml();
+          final renderedFile = File(p.setExtension(fixtureSpec.path, '.yaml'));
+          renderedFile.writeAsStringSync(rendered);
+
+          final documentJson =
+              jsonDecode(fixtureSpecJson) as Map<String, Object?>;
+          final renderedYaml = loadYaml(rendered);
+          expect(renderedYaml, equals(deepEqualsMap(documentJson)));
+        });
+      });
+    }
+  });
+}
+
+// Copied from `package:yaml`
+
+/// Returns a matcher that asserts that the value equals [expected].
+///
+/// This handles recursive loops and considers `NaN` to equal itself.
+Matcher deepEquals(Object? expected) => predicate(
+    (actual) => equality.deepEquals(actual, expected), 'equals $expected');
+
+/// Constructs a new yaml.YamlMap, optionally from a normal Map.
+Map<Object?, Object?> deepEqualsMap([Map<Object?, Object?>? from]) {
+  final map = equality.deepEqualsMap<Object?, Object?>();
+  if (from != null) map.addAll(from);
+  return map;
+}


### PR DESCRIPTION
- Adds classes and methods for loading OpenAPI documents from JSON/YAML and rendering them to YAML.
- Adds Dart classes for representing OpenAPI types in a spec-conformant way but which are easy to traverse.