### PR TITLE
chore(cli): Run `build_runner` daemon with `celest start`

### DIFF
--- a/apps/cli/lib/src/project/celest_project.dart
+++ b/apps/cli/lib/src/project/celest_project.dart
@@ -193,6 +193,11 @@ final class CelestProject {
   Pubspec get pubspec => _cachedPubspec.pubspec;
   String get pubspecYaml => _cachedPubspec.pubspecYaml;
 
+  /// Whether the project uses `package:build_runner`.
+  bool get usesBuildRunner {
+    return pubspec.devDependencies.containsKey('build_runner');
+  }
+
   late final _cachedClientPubspec = CachedPubspec(
     fileSystem.directory(projectPaths.clientRoot).childFile('pubspec.yaml'),
   );

--- a/examples/tasks/celest/lib/src/database/task_database.g.dart
+++ b/examples/tasks/celest/lib/src/database/task_database.g.dart
@@ -25,8 +25,6 @@ class $TasksTable extends Tasks with TableInfo<$TasksTable, Task> {
           GeneratedColumn.checkTextLength(minTextLength: 1, maxTextLength: 100),
       type: DriftSqlType.string,
       requiredDuringInsert: true);
-  static const VerificationMeta _priorityMeta =
-      const VerificationMeta('priority');
   @override
   late final GeneratedColumnWithTypeConverter<Priority, String> priority =
       GeneratedColumn<String>('priority', aliasedName, false,
@@ -63,7 +61,6 @@ class $TasksTable extends Tasks with TableInfo<$TasksTable, Task> {
     } else if (isInserting) {
       context.missing(_titleMeta);
     }
-    context.handle(_priorityMeta, const VerificationResult.success());
     if (data.containsKey('completed')) {
       context.handle(_completedMeta,
           completed.isAcceptableOrUnknown(data['completed']!, _completedMeta));

--- a/examples/tasks/celest/lib/src/generated/data.celest.dart
+++ b/examples/tasks/celest/lib/src/generated/data.celest.dart
@@ -24,8 +24,8 @@ class CelestData {
         context,
         name: 'TaskDatabase',
         factory: TaskDatabase.new,
-        hostnameVariable: const _$celest.env('CELEST_DATABASE_HOST'),
-        tokenSecret: const _$celest.secret('CELEST_DATABASE_TOKEN'),
+        hostnameVariable: const _$celest.env('TASK_DATABASE_HOST'),
+        tokenSecret: const _$celest.secret('TASK_DATABASE_TOKEN'),
       ),
     );
   }

--- a/packages/celest_cloud/pubspec.yaml
+++ b/packages/celest_cloud/pubspec.yaml
@@ -9,7 +9,7 @@ resolution: workspace
 
 dependencies:
   async: ^2.11.0
-  celest_ast: ^0.1.6-0
+  celest_ast: ^0.1.5
   celest_core: ^1.0.0
   code_builder: ^4.10.0
   collection: ^1.18.0


### PR DESCRIPTION
Instead of requiring a separate build_runner dev cycle when using Drift or others, manage a build_runner daemon for the user with `celest start`.