### PR TITLE
feat(cli): Add templates to `celest init`

### DIFF
--- a/.github/workflows/celest_cli.yaml
+++ b/.github/workflows/celest_cli.yaml
@@ -46,7 +46,7 @@ jobs:
         run: tool/setup-ci.sh
       - name: Get Packages
         working-directory: apps/cli
-        run: dart pub upgrade
+        run: dart pub upgrade --verbose
       - name: Test
         working-directory: apps/cli
         run: dart test -x e2e --fail-fast -j 1

--- a/apps/cli/lib/src/commands/init_command.dart
+++ b/apps/cli/lib/src/commands/init_command.dart
@@ -15,6 +15,17 @@ final class InitCommand extends CelestCommand with Configure, ProjectCreator {
       hide: true,
       defaultsTo: true,
     );
+    argParser.addOption(
+      'template',
+      abbr: 't',
+      help: 'The project template to use.',
+      allowed: ['hello', 'data'],
+      allowedHelp: {
+        'hello': 'A simple greeting API.',
+        'data': 'A project with a database and cloud functions.',
+      },
+      defaultsTo: 'hello',
+    );
   }
 
   @override
@@ -28,6 +39,9 @@ final class InitCommand extends CelestCommand with Configure, ProjectCreator {
 
   @override
   Progress? currentProgress;
+
+  @override
+  late final String template = argResults!.option('template')!;
 
   /// Precache assets in the background.
   Future<void> _precacheInBackground() async {
@@ -97,9 +111,9 @@ final class InitCommand extends CelestCommand with Configure, ProjectCreator {
     stdout.writeln();
     cliLogger.success('🚀 To start a local development server, run:');
     cliLogger
-      ..info(Platform.lineTerminator)
-      ..info('      $command${Platform.lineTerminator}')
-      ..info(Platform.lineTerminator);
+      ..info('')
+      ..info('      $command')
+      ..info('');
 
     return 0;
   }

--- a/apps/cli/lib/src/commands/start_command.dart
+++ b/apps/cli/lib/src/commands/start_command.dart
@@ -8,7 +8,20 @@ import 'package:mason_logger/mason_logger.dart';
 
 final class StartCommand extends CelestCommand
     with Configure, Migrate, ProjectCreator {
-  StartCommand();
+  StartCommand() {
+    argParser.addOption(
+      'template',
+      abbr: 't',
+      help: 'The project template to use.',
+      allowed: ['hello', 'data'],
+      allowedHelp: {
+        'hello': 'A simple greeting API.',
+        'data': 'A project with a database and cloud functions.',
+      },
+      defaultsTo: 'hello',
+      hide: true,
+    );
+  }
 
   @override
   String get description => 'Starts a local Celest environment.';
@@ -21,6 +34,9 @@ final class StartCommand extends CelestCommand
 
   @override
   Progress? currentProgress;
+
+  @override
+  late final String template = argResults!.option('template')!;
 
   @override
   Future<int> run() async {

--- a/apps/cli/lib/src/init/project_generator.dart
+++ b/apps/cli/lib/src/init/project_generator.dart
@@ -1,20 +1,32 @@
 import 'package:celest_cli/src/init/migrations/add_analyzer_plugin.dart';
 import 'package:celest_cli/src/init/migrations/macos_entitlements.dart';
 import 'package:celest_cli/src/init/project_migration.dart';
+import 'package:celest_cli/src/init/templates/project_template.dart';
 import 'package:celest_cli/src/project/celest_project.dart';
 import 'package:celest_cli/src/sdk/dart_sdk.dart';
+
+typedef ProjectTemplateFactory = ProjectTemplate Function(
+  String projectRoot,
+  String projectName,
+  String projectDisplayName,
+);
 
 /// Manages the generation of a new Celest project.
 class ProjectGenerator {
   ProjectGenerator({
     required this.projectName,
+    required this.projectDisplayName,
     required this.parentProject,
+    this.projectTemplate = HelloProject.new,
     required this.projectRoot,
   });
 
+  /// The sanitized name of the project.
+  final String projectName;
+
   /// The name of the project to initialize, as chosen by the user
   /// when running `celest start` for the first time.
-  final String projectName;
+  final String projectDisplayName;
 
   /// The root directory of the enclosing Flutter project.
   ///
@@ -23,17 +35,32 @@ class ProjectGenerator {
   /// Flutter code.
   final ParentProject? parentProject;
 
+  /// The project template to use for the migration.
+  final ProjectTemplateFactory projectTemplate;
+
   /// The root directory of the initialized Celest project.
   final String projectRoot;
 
   /// Generates a new Celest project.
   Future<void> generate() async {
+    final template = projectTemplate(
+      projectRoot,
+      projectName,
+      projectDisplayName,
+    );
     await Future.wait(
       [
         ProjectFile.gitIgnore(projectRoot),
         ProjectFile.analysisOptions(projectRoot),
-        ProjectFile.pubspec(projectRoot, projectName, parentProject),
-        ProjectTemplate.hello(projectRoot, projectName),
+        ProjectFile.pubspec(
+          projectRoot,
+          projectName: projectName,
+          projectDisplayName: projectDisplayName,
+          parentProject: parentProject,
+          additionalDependencies: template.additionalDependencies,
+        ),
+        ProjectFile.client(projectRoot, projectName),
+        template,
         if (parentProject
             case ParentProject(
               path: final appRoot,

--- a/apps/cli/lib/src/init/templates/data_project.dart
+++ b/apps/cli/lib/src/init/templates/data_project.dart
@@ -1,0 +1,549 @@
+part of 'project_template.dart';
+
+/// A project template for Celest that includes a simple database.
+final class DataProject extends ProjectTemplate {
+  DataProject(super.projectRoot, this.projectName, this.projectDisplayName);
+
+  @override
+  String get name => 'core.template.data';
+
+  @override
+  bool get needsMigration => true;
+
+  final String projectName;
+  final String projectDisplayName;
+
+  @override
+  List<ProjectDependency> get additionalDependencies => [
+        ProjectDependency.drift,
+      ];
+
+  @override
+  Future<ProjectMigrationResult> create() async {
+    final databaseName = '${projectDisplayName.pascalCase}Database';
+
+    await Future.wait([
+      createFile(projectPaths.projectDart, '''
+import 'package:celest/celest.dart';
+import 'package:celest_backend/src/database/database.dart';
+
+const project = Project(
+  name: '${projectName.paramCase}',
+  displayName: '$projectDisplayName',
+);
+
+const database = Database(
+  schema: Schema.drift($databaseName),
+);
+'''),
+
+      // Database files
+      createFile(
+        p.join(
+          projectPaths.projectLib,
+          'src',
+          'database',
+          'database.dart',
+        ),
+        '''
+import 'package:drift/drift.dart';
+
+part 'database.g.dart';
+
+class Tasks extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get title => text().withLength(min: 1, max: 100)();
+  BoolColumn get completed => boolean().withDefault(const Constant(false))();
+}
+
+@DriftDatabase(tables: [Tasks])
+class $databaseName extends _\$$databaseName {
+  $databaseName(super.e);
+
+  @override
+  int get schemaVersion => 1;
+}
+''',
+      ),
+      createFile(
+          p.join(
+            projectPaths.projectLib,
+            'src',
+            'database',
+            'database.g.dart',
+          ),
+          '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'database.dart';
+
+// ignore_for_file: type=lint
+class \$TasksTable extends Tasks with TableInfo<\$TasksTable, Task> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  \$TasksTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 100,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _completedMeta = const VerificationMeta(
+    'completed',
+  );
+  @override
+  late final GeneratedColumn<bool> completed = GeneratedColumn<bool>(
+    'completed',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("completed" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  @override
+  List<GeneratedColumn> get \$columns => [id, title, completed];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => \$name;
+  static const String \$name = 'tasks';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<Task> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('completed')) {
+      context.handle(
+        _completedMeta,
+        completed.isAcceptableOrUnknown(data['completed']!, _completedMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get \$primaryKey => {id};
+  @override
+  Task map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '\$tablePrefix.' : '';
+    return Task(
+      id:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.int,
+            data['\${effectivePrefix}id'],
+          )!,
+      title:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['\${effectivePrefix}title'],
+          )!,
+      completed:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.bool,
+            data['\${effectivePrefix}completed'],
+          )!,
+    );
+  }
+
+  @override
+  \$TasksTable createAlias(String alias) {
+    return \$TasksTable(attachedDatabase, alias);
+  }
+}
+
+class Task extends DataClass implements Insertable<Task> {
+  final int id;
+  final String title;
+  final bool completed;
+  const Task({required this.id, required this.title, required this.completed});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['title'] = Variable<String>(title);
+    map['completed'] = Variable<bool>(completed);
+    return map;
+  }
+
+  TasksCompanion toCompanion(bool nullToAbsent) {
+    return TasksCompanion(
+      id: Value(id),
+      title: Value(title),
+      completed: Value(completed),
+    );
+  }
+
+  factory Task.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Task(
+      id: serializer.fromJson<int>(json['id']),
+      title: serializer.fromJson<String>(json['title']),
+      completed: serializer.fromJson<bool>(json['completed']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'title': serializer.toJson<String>(title),
+      'completed': serializer.toJson<bool>(completed),
+    };
+  }
+
+  Task copyWith({int? id, String? title, bool? completed}) => Task(
+    id: id ?? this.id,
+    title: title ?? this.title,
+    completed: completed ?? this.completed,
+  );
+  Task copyWithCompanion(TasksCompanion data) {
+    return Task(
+      id: data.id.present ? data.id.value : this.id,
+      title: data.title.present ? data.title.value : this.title,
+      completed: data.completed.present ? data.completed.value : this.completed,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Task(')
+          ..write('id: \$id, ')
+          ..write('title: \$title, ')
+          ..write('completed: \$completed')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, title, completed);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Task &&
+          other.id == this.id &&
+          other.title == this.title &&
+          other.completed == this.completed);
+}
+
+class TasksCompanion extends UpdateCompanion<Task> {
+  final Value<int> id;
+  final Value<String> title;
+  final Value<bool> completed;
+  const TasksCompanion({
+    this.id = const Value.absent(),
+    this.title = const Value.absent(),
+    this.completed = const Value.absent(),
+  });
+  TasksCompanion.insert({
+    this.id = const Value.absent(),
+    required String title,
+    this.completed = const Value.absent(),
+  }) : title = Value(title);
+  static Insertable<Task> custom({
+    Expression<int>? id,
+    Expression<String>? title,
+    Expression<bool>? completed,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (title != null) 'title': title,
+      if (completed != null) 'completed': completed,
+    });
+  }
+
+  TasksCompanion copyWith({
+    Value<int>? id,
+    Value<String>? title,
+    Value<bool>? completed,
+  }) {
+    return TasksCompanion(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      completed: completed ?? this.completed,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (completed.present) {
+      map['completed'] = Variable<bool>(completed.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TasksCompanion(')
+          ..write('id: \$id, ')
+          ..write('title: \$title, ')
+          ..write('completed: \$completed')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _\$$databaseName extends GeneratedDatabase {
+  _\$$databaseName(QueryExecutor e) : super(e);
+  \$${databaseName}Manager get managers => \$${databaseName}Manager(this);
+  late final \$TasksTable tasks = \$TasksTable(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [tasks];
+}
+
+typedef \$\$TasksTableCreateCompanionBuilder =
+    TasksCompanion Function({
+      Value<int> id,
+      required String title,
+      Value<bool> completed,
+    });
+typedef \$\$TasksTableUpdateCompanionBuilder =
+    TasksCompanion Function({
+      Value<int> id,
+      Value<String> title,
+      Value<bool> completed,
+    });
+
+class \$\$TasksTableFilterComposer
+    extends Composer<_\$$databaseName, \$TasksTable> {
+  \$\$TasksTableFilterComposer({
+    required super.\$db,
+    required super.\$table,
+    super.joinBuilder,
+    super.\$addJoinBuilderToRootComposer,
+    super.\$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => \$composableBuilder(
+    column: \$table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => \$composableBuilder(
+    column: \$table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get completed => \$composableBuilder(
+    column: \$table.completed,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class \$\$TasksTableOrderingComposer
+    extends Composer<_\$$databaseName, \$TasksTable> {
+  \$\$TasksTableOrderingComposer({
+    required super.\$db,
+    required super.\$table,
+    super.joinBuilder,
+    super.\$addJoinBuilderToRootComposer,
+    super.\$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => \$composableBuilder(
+    column: \$table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => \$composableBuilder(
+    column: \$table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get completed => \$composableBuilder(
+    column: \$table.completed,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class \$\$TasksTableAnnotationComposer
+    extends Composer<_\$$databaseName, \$TasksTable> {
+  \$\$TasksTableAnnotationComposer({
+    required super.\$db,
+    required super.\$table,
+    super.joinBuilder,
+    super.\$addJoinBuilderToRootComposer,
+    super.\$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      \$composableBuilder(column: \$table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      \$composableBuilder(column: \$table.title, builder: (column) => column);
+
+  GeneratedColumn<bool> get completed =>
+      \$composableBuilder(column: \$table.completed, builder: (column) => column);
+}
+
+class \$\$TasksTableTableManager
+    extends
+        RootTableManager<
+          _\$$databaseName,
+          \$TasksTable,
+          Task,
+          \$\$TasksTableFilterComposer,
+          \$\$TasksTableOrderingComposer,
+          \$\$TasksTableAnnotationComposer,
+          \$\$TasksTableCreateCompanionBuilder,
+          \$\$TasksTableUpdateCompanionBuilder,
+          (Task, BaseReferences<_\$$databaseName, \$TasksTable, Task>),
+          Task,
+          PrefetchHooks Function()
+        > {
+  \$\$TasksTableTableManager(_\$$databaseName db, \$TasksTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer:
+              () => \$\$TasksTableFilterComposer(\$db: db, \$table: table),
+          createOrderingComposer:
+              () => \$\$TasksTableOrderingComposer(\$db: db, \$table: table),
+          createComputedFieldComposer:
+              () => \$\$TasksTableAnnotationComposer(\$db: db, \$table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<bool> completed = const Value.absent(),
+              }) => TasksCompanion(id: id, title: title, completed: completed),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String title,
+                Value<bool> completed = const Value.absent(),
+              }) => TasksCompanion.insert(
+                id: id,
+                title: title,
+                completed: completed,
+              ),
+          withReferenceMapper:
+              (p0) =>
+                  p0
+                      .map(
+                        (e) => (
+                          e.readTable(table),
+                          BaseReferences(db, table, e),
+                        ),
+                      )
+                      .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef \$\$TasksTableProcessedTableManager =
+    ProcessedTableManager<
+      _\$$databaseName,
+      \$TasksTable,
+      Task,
+      \$\$TasksTableFilterComposer,
+      \$\$TasksTableOrderingComposer,
+      \$\$TasksTableAnnotationComposer,
+      \$\$TasksTableCreateCompanionBuilder,
+      \$\$TasksTableUpdateCompanionBuilder,
+      (Task, BaseReferences<_\$$databaseName, \$TasksTable, Task>),
+      Task,
+      PrefetchHooks Function()
+    >;
+
+class \$${databaseName}Manager {
+  final _\$$databaseName _db;
+  \$${databaseName}Manager(this._db);
+  \$\$TasksTableTableManager get tasks =>
+      \$\$TasksTableTableManager(_db, _db.tasks);
+}
+'''),
+
+      createFile(p.join(projectPaths.apisDir, 'tasks.dart'), '''
+import 'package:celest/celest.dart';
+import 'package:celest_backend/src/database/database.dart';
+import 'package:celest_backend/src/generated/cloud.celest.dart';
+
+$databaseName get db => celest.data.database;
+
+@cloud
+Future<List<Task>> listAllTasks() async {
+  print('Fetching tasks...');
+  return db.select(db.tasks).get();
+}
+
+@cloud
+Future<Task> addTask({
+  required String title,
+}) async {
+  if (title.trim().isEmpty) {
+    throw ServerException('Title cannot be empty');
+  }
+  final newTask = TasksCompanion.insert(
+    title: title,
+  );
+  print('Creating task: \$newTask');
+  final task = await db.into(db.tasks).insertReturning(newTask);
+  print('Task created: \$task');
+  return task;
+}
+
+class ServerException implements Exception {
+  const ServerException(this.message);
+
+  final String message;
+}
+'''),
+
+      // Generated
+      createFile(
+        p.join(projectPaths.generatedDir, 'README.md'),
+        generated_README,
+      ),
+    ]);
+    return const ProjectMigrationSuccess();
+  }
+}

--- a/apps/cli/lib/src/init/templates/hello_project.dart
+++ b/apps/cli/lib/src/init/templates/hello_project.dart
@@ -1,0 +1,94 @@
+part of 'project_template.dart';
+
+/// A simple project template -- the "Hello World" of Celest.
+final class HelloProject extends ProjectTemplate {
+  HelloProject(super.projectRoot, this.projectName, this.projectDisplayName);
+
+  @override
+  String get name => 'core.template.hello';
+
+  @override
+  bool get needsMigration => true;
+
+  final String projectName;
+  final String projectDisplayName;
+
+  @override
+  Future<ProjectMigrationResult> create() async {
+    await Future.wait([
+      createFile(projectPaths.projectDart, '''
+import 'package:celest/celest.dart';
+
+const project = Project(
+  name: '${projectName.paramCase}',
+  displayName: '$projectDisplayName',
+);
+'''),
+      createFile(p.join(projectPaths.apisDir, 'greeting.dart'), r'''
+// Cloud functions are top-level Dart functions defined in the `functions/`
+// folder of your Celest project.
+
+import 'package:celest/celest.dart';
+
+/// Says hello to a [person].
+@cloud
+Future<String> sayHello({required Person person}) async {
+  if (person.name.isEmpty) {
+    // Throw a custom exception and catch it on the frontend.
+    throw BadNameException('Name cannot be empty');
+  }
+
+  // Logging is handled automatically when you print to the console.
+  print('Saying hello to ${person.name}');
+
+  return 'Hello, ${person.name}!';
+}
+
+/// A person who can be greeted.
+class Person {
+  const Person({required this.name});
+
+  final String name;
+}
+
+/// Thrown when a [Person] has an invalid name.
+class BadNameException implements Exception {
+  const BadNameException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'BadNameException: $message';
+}
+'''),
+      createFile(
+        p.join(projectRoot, 'test', 'functions', 'greeting_test.dart'),
+        '''
+import 'package:celest_backend/src/functions/greeting.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('greeting', () {
+    test('sayHello', () async {
+      expect(await sayHello(person: Person(name: 'Celest')), 'Hello, Celest!');
+    });
+    test('sayHello (empty name)', () async {
+      expect(
+        sayHello(person: Person(name: '')),
+        throwsA(isA<BadNameException>()),
+      );
+    });
+  });
+}
+''',
+      ),
+
+      // Generated
+      createFile(
+        p.join(projectPaths.generatedDir, 'README.md'),
+        generated_README,
+      ),
+    ]);
+    return const ProjectMigrationSuccess();
+  }
+}

--- a/apps/cli/lib/src/init/templates/project_template.dart
+++ b/apps/cli/lib/src/init/templates/project_template.dart
@@ -1,0 +1,20 @@
+import 'package:celest_cli/src/context.dart';
+import 'package:celest_cli/src/init/migrations/add_generated_folder.dart';
+import 'package:celest_cli/src/init/project_migration.dart';
+import 'package:celest_cli/src/pub/project_dependency.dart';
+import 'package:celest_cli/src/utils/recase.dart';
+
+part 'data_project.dart';
+part 'hello_project.dart';
+
+sealed class ProjectTemplate extends ProjectMigration {
+  const ProjectTemplate(super.projectRoot);
+
+  factory ProjectTemplate.hello(
+    String projectRoot,
+    String projectName,
+    String projectDisplayName,
+  ) = HelloProject;
+
+  List<ProjectDependency> get additionalDependencies => const [];
+}

--- a/apps/cli/lib/src/pub/project_dependency.dart
+++ b/apps/cli/lib/src/pub/project_dependency.dart
@@ -111,6 +111,19 @@ final class ProjectDependency {
     ),
   );
 
+  static final ProjectDependency drift = ProjectDependency._(
+    'drift',
+    DependencyType.dependency,
+    HostedDependency(
+      version: VersionRange(
+        min: Version.parse('2.26.0'),
+        max: Version.parse('2.27.0'),
+        includeMin: true,
+        includeMax: false,
+      ),
+    ),
+  );
+
   static final ProjectDependency driftHrana = ProjectDependency._(
     'drift_hrana',
     DependencyType.dependency,

--- a/apps/cli/pubspec.yaml
+++ b/apps/cli/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   convert: ^3.1.1
   corks_cedar: ^0.2.1
   crypto: ^3.0.3
+  dart_console: ^4.1.1
   dart_style: ^3.0.0
   dcli: ^7.0.1
   dcli_terminal: ^7.0.1

--- a/apps/cli/test/e2e/e2e_test.dart
+++ b/apps/cli/test/e2e/e2e_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_import, flutter_style_todos
+// ignore_for_file: unused_import
 
 import 'dart:io';
 
@@ -12,10 +12,11 @@ import 'features/create/create_project_in_dart_app.dart';
 import 'features/create/create_project_in_dart_app_no_deps.dart';
 import 'features/create/create_project_in_flutter_app.dart';
 import 'features/create/create_project_isolated.dart';
-import 'features/hello_project.dart';
 import 'features/hot_reload/hot_reload_add_auth.dart';
 import 'features/hot_reload/hot_reload_add_model_after_error.dart';
 import 'features/package_support/supports_supabase.dart';
+import 'features/templates/data_project.dart';
+import 'features/templates/hello_project.dart';
 import 'targets/installed_target.dart';
 import 'targets/local_aot_target.dart';
 import 'targets/local_target.dart';
@@ -30,6 +31,7 @@ void main() {
   final tests = <E2ETest Function(TestTarget)>[
     // Example projects
     HelloProjectTest.new,
+    DataProjectTest.new,
 
     // Project creation
     CreateProjectInFlutterAppTest.new,

--- a/apps/cli/test/e2e/features/templates/data_project.dart
+++ b/apps/cli/test/e2e/features/templates/data_project.dart
@@ -1,0 +1,25 @@
+import 'package:celest_cli/src/context.dart';
+
+import '../../common/common.dart';
+
+final class DataProjectTest extends E2ETest {
+  DataProjectTest(super.target);
+
+  @override
+  String get name => 'init (data template)';
+
+  @override
+  Future<void> run() async {
+    await celestCommand('init', '-t', 'data')
+        .workingDirectory(tempDir.path)
+        .start()
+        .expectLater('🚀 To start a local development server')
+        .run();
+    await celestCommand('start')
+        .workingDirectory(p.join(tempDir.path, 'my_project'))
+        .start()
+        .expectLater('Starting local environment')
+        .expectLater('Celest is running')
+        .run();
+  }
+}

--- a/apps/cli/test/e2e/features/templates/hello_project.dart
+++ b/apps/cli/test/e2e/features/templates/hello_project.dart
@@ -1,25 +1,22 @@
-import 'dart:io';
-
 import 'package:celest_cli/src/context.dart';
 
-import '../common/common.dart';
+import '../../common/common.dart';
 
 final class HelloProjectTest extends E2ETest {
   HelloProjectTest(super.target);
 
   @override
-  String get name => 'start (hello project)';
-
-  @override
-  bool get skip => !hasFlutter || !platform.environment.containsKey('CI');
+  String get name => 'init (hello template)';
 
   @override
   Future<void> run() async {
-    final helloExample = Directory.current.uri
-        .resolve('../../packages/celest/example')
-        .toFilePath();
+    await celestCommand('init', '-t', 'hello')
+        .workingDirectory(tempDir.path)
+        .start()
+        .expectLater('🚀 To start a local development server')
+        .run();
     await celestCommand('start')
-        .workingDirectory(helloExample)
+        .workingDirectory(p.join(tempDir.path, 'my_project'))
         .start()
         .expectLater('Starting local environment')
         .expectNext('Celest is running')

--- a/apps/cli/test/init/project_item_test.dart
+++ b/apps/cli/test/init/project_item_test.dart
@@ -200,8 +200,9 @@ environment:
       await tempDir.childFile('pubspec.yaml').writeAsString(pubspecYaml);
       await PubspecFile(
         p.join(tempDir.path, 'celest'),
-        'barebones',
-        ParentProject(
+        projectName: 'barebones',
+        projectDisplayName: 'Barebones',
+        parentProject: ParentProject(
           name: 'barebones',
           path: tempDir.path,
           pubspec: Pubspec.parse(pubspecYaml),
@@ -255,8 +256,9 @@ dev_dependencies:
       await tempDir.childFile('pubspec.yaml').writeAsString(pubspecYaml);
       await PubspecFile(
         p.join(tempDir.path, 'celest'),
-        'empty',
-        ParentProject(
+        projectName: 'empty',
+        projectDisplayName: 'Empty',
+        parentProject: ParentProject(
           name: 'empty',
           path: tempDir.path,
           pubspec: Pubspec.parse(pubspecYaml),
@@ -293,6 +295,25 @@ dev_dependencies:
       expect(updatedPubspec.dependencies, contains('empty_client'));
     });
 
+    test('non-existent dart project', () async {
+      await PubspecFile(
+        tempDir.path,
+        projectName: 'my_project',
+        projectDisplayName: 'My Project',
+      ).create();
+
+      final pubspecFile =
+          await tempDir.childFile('pubspec.yaml').readAsString();
+      expect(
+        pubspecFile,
+        startsWith('''
+name: celest_backend
+description: The Celest backend for My Project.
+'''),
+        reason: 'The given name is included as-is for the description.',
+      );
+    });
+
     test('existing dart project', () async {
       const pubspecYaml = '''
 name: existing
@@ -314,8 +335,9 @@ dev_dependencies:
       await tempDir.childFile('pubspec.yaml').writeAsString(pubspecYaml);
       await PubspecFile(
         p.join(tempDir.path, 'celest'),
-        'existing',
-        ParentProject(
+        projectName: 'existing',
+        projectDisplayName: 'Existing',
+        parentProject: ParentProject(
           name: 'existing',
           path: tempDir.path,
           pubspec: Pubspec.parse(pubspecYaml),
@@ -375,8 +397,9 @@ dev_dependencies:
       await tempDir.childFile('pubspec.yaml').writeAsString(pubspecYaml);
       await PubspecFile(
         p.join(tempDir.path, 'celest'),
-        'existing',
-        ParentProject(
+        projectName: 'existing',
+        projectDisplayName: 'Existing',
+        parentProject: ParentProject(
           name: 'existing',
           path: tempDir.path,
           pubspec: Pubspec.parse(pubspecYaml),


### PR DESCRIPTION
- Adds two templates to `celest init`: the exiting `hello` template and a `data` template which is a slim version of the `tasks` example project.
- Fixes some false-positive errors when running `celest start` from a generated template where codegen is required.