### PR TITLE
feat(cli): Add `celest status` command

### DIFF
--- a/apps/cli/bin/celest.dart
+++ b/apps/cli/bin/celest.dart
@@ -4,6 +4,7 @@ import 'package:celest_cli/src/commands/deploy_command.dart';
 import 'package:celest_cli/src/commands/organizations/organizations_command.dart';
 import 'package:celest_cli/src/commands/project_environments/project_environments_command.dart';
 import 'package:celest_cli/src/commands/projects/projects_command.dart';
+import 'package:celest_cli/src/commands/status_command.dart';
 
 void main(List<String> args) async {
   final cli = Cli(
@@ -19,7 +20,8 @@ void main(List<String> args) async {
     ..addCommand(UninstallCommand())
     ..addCommand(PrecacheCommand())
     ..addCommand(DeployCommand())
-    ..addCommand(AuthCommand());
+    ..addCommand(AuthCommand())
+    ..addCommand(StatusCommand());
 
   // Cloud API commands
   cli

--- a/apps/cli/lib/src/commands/status_command.dart
+++ b/apps/cli/lib/src/commands/status_command.dart
@@ -1,0 +1,48 @@
+import 'package:celest_cli/src/commands/authenticate.dart';
+import 'package:celest_cli/src/commands/celest_command.dart';
+import 'package:celest_cli/src/context.dart';
+import 'package:celest_cli/src/init/project_init.dart';
+import 'package:mason_logger/mason_logger.dart';
+
+final class StatusCommand extends CelestCommand with Configure, Authenticate {
+  StatusCommand();
+
+  @override
+  String get description => 'Gets the status of the Celest Cloud project.';
+
+  @override
+  String get name => 'status';
+
+  @override
+  String get category => 'Project';
+
+  @override
+  Progress? currentProgress;
+
+  @override
+  Future<int> run() async {
+    await super.run();
+
+    await assertAuthenticated();
+    await configure();
+
+    final projectName = celestProject.projectName;
+    final projectEnvironment = await cloud.projects.environments
+        .get('projects/$projectName/environments/production');
+    if (projectEnvironment == null) {
+      cliLogger.warn(
+        'This project has not been deployed yet. '
+        'Run `celest deploy` to deploy it.',
+      );
+      return 1;
+    }
+
+    cliLogger
+      ..success('🚀 Project is live on Celest Cloud!')
+      ..info('Project: $projectName')
+      ..info('Environment: production')
+      ..info('URL: ${projectEnvironment.uri}');
+
+    return 0;
+  }
+}

--- a/packages/celest_cloud/lib/src/proto/celest/cloud/v1alpha1/project_environments.pb.dart
+++ b/packages/celest_cloud/lib/src/proto/celest/cloud/v1alpha1/project_environments.pb.dart
@@ -36,6 +36,7 @@ class ProjectEnvironment extends $pb.GeneratedMessage {
     $core.Map<$core.String, $core.String>? annotations,
     $core.bool? reconciling,
     $17.LifecycleState? state,
+    $core.String? uri,
   }) {
     final $result = create();
     if (name != null) {
@@ -73,6 +74,9 @@ class ProjectEnvironment extends $pb.GeneratedMessage {
     }
     if (state != null) {
       $result.state = state;
+    }
+    if (uri != null) {
+      $result.uri = uri;
     }
     return $result;
   }
@@ -112,6 +116,7 @@ class ProjectEnvironment extends $pb.GeneratedMessage {
         defaultOrMaker: $17.LifecycleState.LIFECYCLE_STATE_UNSPECIFIED,
         valueOf: $17.LifecycleState.valueOf,
         enumValues: $17.LifecycleState.values)
+    ..aOS(13, _omitFieldNames ? '' : 'uri')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -293,6 +298,21 @@ class ProjectEnvironment extends $pb.GeneratedMessage {
   $core.bool hasState() => $_has(11);
   @$pb.TagNumber(12)
   void clearState() => clearField(12);
+
+  ///  Output only. The hosted URI of the environment.
+  ///
+  ///  Will be empty if the environment is not yet deployed.
+  @$pb.TagNumber(13)
+  $core.String get uri => $_getSZ(12);
+  @$pb.TagNumber(13)
+  set uri($core.String v) {
+    $_setString(12, v);
+  }
+
+  @$pb.TagNumber(13)
+  $core.bool hasUri() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearUri() => clearField(13);
 }
 
 /// Request message for the `CreateProjectEnvironment` method.

--- a/packages/celest_cloud/lib/src/proto/celest/cloud/v1alpha1/project_environments.pbjson.dart
+++ b/packages/celest_cloud/lib/src/proto/celest/cloud/v1alpha1/project_environments.pbjson.dart
@@ -76,6 +76,7 @@ const ProjectEnvironment$json = {
       '8': {},
       '10': 'state'
     },
+    {'1': 'uri', '3': 13, '4': 1, '5': 9, '8': {}, '10': 'uri'},
   ],
   '3': [ProjectEnvironment_AnnotationsEntry$json],
   '7': {},
@@ -111,11 +112,11 @@ final $typed_data.Uint8List projectEnvironmentDescriptor = $convert.base64Decode
     'BoYXZlIG9ubHkgbG93ZXJjYXNlIGxldHRlcnMsIG51bWVyaWNzLCB1bmRlcnNjb3JlcywgYW5k'
     'IGRhc2hlcxoidGhpcy5tYXRjaGVzKCdeW2EtejAtOV8tXXswLDYzfSQnKVILYW5ub3RhdGlvbn'
     'MSJQoLcmVjb25jaWxpbmcYCyABKAhCA+BBA1ILcmVjb25jaWxpbmcSQAoFc3RhdGUYDCABKA4y'
-    'JS5jZWxlc3QuY2xvdWQudjFhbHBoYTEuTGlmZWN5Y2xlU3RhdGVCA+BBA1IFc3RhdGUaPgoQQW'
-    '5ub3RhdGlvbnNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6'
-    'AjgBOoQB6kGAAQojY2xvdWQuY2VsZXN0LmRldi9Qcm9qZWN0RW52aXJvbm1lbnQSLXByb2plY3'
-    'RzL3twcm9qZWN0fS9lbnZpcm9ubWVudHMve2Vudmlyb25tZW50fSoTcHJvamVjdEVudmlyb25t'
-    'ZW50czIScHJvamVjdEVudmlyb25tZW50UgEB');
+    'JS5jZWxlc3QuY2xvdWQudjFhbHBoYTEuTGlmZWN5Y2xlU3RhdGVCA+BBA1IFc3RhdGUSFQoDdX'
+    'JpGA0gASgJQgPgQQNSA3VyaRo+ChBBbm5vdGF0aW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5'
+    'EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE6hAHqQYABCiNjbG91ZC5jZWxlc3QuZGV2L1Byb2'
+    'plY3RFbnZpcm9ubWVudBItcHJvamVjdHMve3Byb2plY3R9L2Vudmlyb25tZW50cy97ZW52aXJv'
+    'bm1lbnR9KhNwcm9qZWN0RW52aXJvbm1lbnRzMhJwcm9qZWN0RW52aXJvbm1lbnRSAQE=');
 
 @$core.Deprecated('Use createProjectEnvironmentRequestDescriptor instead')
 const CreateProjectEnvironmentRequest$json = {

--- a/proto/celest/cloud/v1alpha1/project_environments.proto
+++ b/proto/celest/cloud/v1alpha1/project_environments.proto
@@ -163,6 +163,11 @@ message ProjectEnvironment {
 
   // Output only. The current state of the environment.
   LifecycleState state = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. The hosted URI of the environment.
+  //
+  // Will be empty if the environment is not yet deployed.
+  string uri = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Request message for the `CreateProjectEnvironment` method.

--- a/services/celest_cloud_hub/.dockerignore
+++ b/services/celest_cloud_hub/.dockerignore
@@ -2,6 +2,8 @@
 Dockerfile
 build/
 example/
+examples/
+fixtures/
 .dart_tool/
 .git/
 .github/

--- a/services/celest_cloud_hub/lib/src/database/schema/operations.drift
+++ b/services/celest_cloud_hub/lib/src/database/schema/operations.drift
@@ -166,11 +166,6 @@ END;
 -------------- /Cedar Triggers ---------------
 ----------------------------------------------
 
-getOperation:
-    SELECT * FROM operations 
-    WHERE id = :id
-    LIMIT 1;
-
 createOperation:
     INSERT INTO operations (
         id,
@@ -194,6 +189,25 @@ createOperation:
         :resource_id
     )
     RETURNING *;
+
+getOperation:
+    SELECT * FROM operations 
+    WHERE id = :id
+    LIMIT 1;
+
+findOperationsByOwner:
+    SELECT * FROM operations 
+    WHERE owner_type = :owner_type
+    AND owner_id = :owner_id
+    ORDER BY $orderBy
+    LIMIT :limit;
+
+findOperationsByResource:
+    SELECT * FROM operations 
+    WHERE resource_type = :resource_type
+    AND resource_id = :resource_id
+    ORDER BY $orderBy
+    LIMIT :limit;
 
 listOperations(
     :owner_type AS TEXT OR NULL,

--- a/services/celest_cloud_hub/lib/src/database/schema/operations.drift.dart
+++ b/services/celest_cloud_hub/lib/src/database/schema/operations.drift.dart
@@ -1091,14 +1091,6 @@ i0.Trigger get operationsTriggerDelete => i0.Trigger(
 
 class OperationsDrift extends i2.ModularAccessor {
   OperationsDrift(i0.GeneratedDatabase db) : super(db);
-  i0.Selectable<i1.Operation> getOperation({required String id}) {
-    return customSelect(
-      'SELECT * FROM operations WHERE id = ?1 LIMIT 1',
-      variables: [i0.Variable<String>(id)],
-      readsFrom: {operations},
-    ).asyncMap(operations.mapFromRow);
-  }
-
   i3.Future<List<i1.Operation>> createOperation({
     required String id,
     String? metadata,
@@ -1125,6 +1117,62 @@ class OperationsDrift extends i2.ModularAccessor {
       ],
       updates: {operations},
     ).then((rows) => Future.wait(rows.map(operations.mapFromRow)));
+  }
+
+  i0.Selectable<i1.Operation> getOperation({required String id}) {
+    return customSelect(
+      'SELECT * FROM operations WHERE id = ?1 LIMIT 1',
+      variables: [i0.Variable<String>(id)],
+      readsFrom: {operations},
+    ).asyncMap(operations.mapFromRow);
+  }
+
+  i0.Selectable<i1.Operation> findOperationsByOwner({
+    String? ownerType,
+    String? ownerId,
+    FindOperationsByOwner$orderBy? orderBy,
+    required int limit,
+  }) {
+    var $arrayStartIndex = 4;
+    final generatedorderBy = $write(
+      orderBy?.call(this.operations) ?? const i0.OrderBy.nothing(),
+      startIndex: $arrayStartIndex,
+    );
+    $arrayStartIndex += generatedorderBy.amountOfVariables;
+    return customSelect(
+      'SELECT * FROM operations WHERE owner_type = ?1 AND owner_id = ?2 ${generatedorderBy.sql} LIMIT ?3',
+      variables: [
+        i0.Variable<String>(ownerType),
+        i0.Variable<String>(ownerId),
+        i0.Variable<int>(limit),
+        ...generatedorderBy.introducedVariables,
+      ],
+      readsFrom: {operations, ...generatedorderBy.watchedTables},
+    ).asyncMap(operations.mapFromRow);
+  }
+
+  i0.Selectable<i1.Operation> findOperationsByResource({
+    String? resourceType,
+    String? resourceId,
+    FindOperationsByResource$orderBy? orderBy,
+    required int limit,
+  }) {
+    var $arrayStartIndex = 4;
+    final generatedorderBy = $write(
+      orderBy?.call(this.operations) ?? const i0.OrderBy.nothing(),
+      startIndex: $arrayStartIndex,
+    );
+    $arrayStartIndex += generatedorderBy.amountOfVariables;
+    return customSelect(
+      'SELECT * FROM operations WHERE resource_type = ?1 AND resource_id = ?2 ${generatedorderBy.sql} LIMIT ?3',
+      variables: [
+        i0.Variable<String>(resourceType),
+        i0.Variable<String>(resourceId),
+        i0.Variable<int>(limit),
+        ...generatedorderBy.introducedVariables,
+      ],
+      readsFrom: {operations, ...generatedorderBy.watchedTables},
+    ).asyncMap(operations.mapFromRow);
   }
 
   i0.Selectable<ListOperationsResult> listOperations({
@@ -1199,6 +1247,11 @@ class OperationsDrift extends i2.ModularAccessor {
   ).resultSet<i1.Operations>('operations');
   i4.CedarDrift get cedarDrift => this.accessor(i4.CedarDrift.new);
 }
+
+typedef FindOperationsByOwner$orderBy =
+    i0.OrderBy Function(i1.Operations operations);
+typedef FindOperationsByResource$orderBy =
+    i0.OrderBy Function(i1.Operations operations);
 
 class ListOperationsResult {
   final int rowNum;

--- a/services/celest_cloud_hub/lib/src/model/interop.dart
+++ b/services/celest_cloud_hub/lib/src/model/interop.dart
@@ -108,7 +108,7 @@ extension ProjectToProto on dto.Project {
 }
 
 extension ProjectEnvironmentToProto on dto.ProjectEnvironment {
-  pb.ProjectEnvironment toProto() {
+  pb.ProjectEnvironment toProto({dto.ProjectEnvironmentState? state}) {
     return pb.ProjectEnvironment(
       name: 'projects/$parentId/environments/$id',
       parent: 'projects/$parentId',
@@ -117,13 +117,17 @@ extension ProjectEnvironmentToProto on dto.ProjectEnvironment {
       displayName: displayName,
       etag: etag,
       reconciling: reconciling,
-      state: pb.LifecycleState.values.firstWhere((s) => s.name == state),
+      state: pb.LifecycleState.values.firstWhere((s) => s.name == this.state),
       createTime: createTime.toProto(),
       updateTime: updateTime.toProto(),
       deleteTime: deleteTime?.toProto(),
       annotations: switch (annotations) {
         final annotations? =>
           (jsonDecode(annotations) as Map<String, Object?>).cast(),
+        _ => null,
+      },
+      uri: switch (state?.domainName) {
+        final domainName? => 'https://$domainName',
         _ => null,
       },
     );


### PR DESCRIPTION
- Adds command to get the status of the Celest project if it's deployed to Celest Cloud.
- Fixes the ability to delete project environments via `celest project-environments delete`.