### PR TITLE
chore(cli): Clean up console input/output

### DIFF
--- a/apps/cli/lib/src/commands/organizations/get_organization_command.dart
+++ b/apps/cli/lib/src/commands/organizations/get_organization_command.dart
@@ -13,6 +13,9 @@ final class GetOrganizationCommand extends CloudGetCommand<Organization> {
   String get resourceType => 'Organization';
 
   @override
+  Organization createEmptyResource() => Organization();
+
+  @override
   Future<Organization?> callService() {
     return cloud.organizations.get(options.resourceId);
   }

--- a/apps/cli/lib/src/commands/organizations/list_organizations_command.dart
+++ b/apps/cli/lib/src/commands/organizations/list_organizations_command.dart
@@ -16,6 +16,9 @@ final class ListOrganizationsCommand extends CloudListCommand<Organization> {
   String? get parentResourceType => null;
 
   @override
+  Organization createEmptyResource() => Organization();
+
+  @override
   Future<CloudListResult<Organization>> callService() async {
     final result = await cloud.organizations.list(
       filter: options.filter,

--- a/apps/cli/lib/src/commands/project_environments/get_project_environment_command.dart
+++ b/apps/cli/lib/src/commands/project_environments/get_project_environment_command.dart
@@ -14,6 +14,9 @@ final class GetProjectEnvironmentCommand
   String get resourceType => 'ProjectEnvironment';
 
   @override
+  ProjectEnvironment createEmptyResource() => ProjectEnvironment();
+
+  @override
   Future<ProjectEnvironment?> callService() {
     return cloud.projects.environments.get(options.resourceId);
   }

--- a/apps/cli/lib/src/commands/project_environments/list_project_environments_command.dart
+++ b/apps/cli/lib/src/commands/project_environments/list_project_environments_command.dart
@@ -17,6 +17,9 @@ final class ListProjectEnvironmentsCommand
   String? get parentResourceType => 'Project';
 
   @override
+  ProjectEnvironment createEmptyResource() => ProjectEnvironment();
+
+  @override
   Future<CloudListResult<ProjectEnvironment>> callService() async {
     final result = await cloud.projects.environments.list(
       parent: options.parentResourceId,

--- a/apps/cli/lib/src/commands/projects/get_project_command.dart
+++ b/apps/cli/lib/src/commands/projects/get_project_command.dart
@@ -13,6 +13,9 @@ final class GetProjectCommand extends CloudGetCommand<Project> {
   String get resourceType => 'Project';
 
   @override
+  Project createEmptyResource() => Project();
+
+  @override
   Future<Project?> callService() {
     return cloud.projects.get(options.resourceId);
   }

--- a/apps/cli/lib/src/commands/projects/list_projects_command.dart
+++ b/apps/cli/lib/src/commands/projects/list_projects_command.dart
@@ -16,6 +16,9 @@ final class ListProjectsCommand extends CloudListCommand<Project> {
   String? get parentResourceType => 'Organization';
 
   @override
+  Project createEmptyResource() => Project();
+
+  @override
   Future<CloudListResult<Project>> callService() async {
     final result = await cloud.projects.list(
       parent: options.parentResourceId,

--- a/apps/cli/lib/src/frontend/celest_frontend.dart
+++ b/apps/cli/lib/src/frontend/celest_frontend.dart
@@ -31,7 +31,6 @@ import 'package:celest_cli/src/utils/process.dart';
 import 'package:celest_cli/src/utils/recase.dart';
 import 'package:celest_cli/src/utils/run.dart';
 import 'package:celest_cloud/src/proto.dart' as pb;
-import 'package:dcli/dcli.dart' as dcli;
 import 'package:logging/logging.dart';
 import 'package:mason_logger/mason_logger.dart' show Progress;
 import 'package:stream_transform/stream_transform.dart';
@@ -500,7 +499,7 @@ final class CelestFrontend {
       var organizationId = organization?.organizationId;
       var organizationDisplayName = organization?.displayName;
       if (organizationId == null) {
-        organizationDisplayName = dcli.ask(
+        organizationDisplayName = cliLogger.prompt(
           'What should we call your organization?',
         );
         if (organizationDisplayName.isEmpty) {


### PR DESCRIPTION
- Use `package:dart_console` for prompting since it handles control sequences better
- Add structured output to `list` commands