### PR TITLE
chore(cli): Pin analyzer version

### DIFF
--- a/apps/cli/pubspec.yaml
+++ b/apps/cli/pubspec.yaml
@@ -9,7 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ^7.3.0
+  # TODO: Remove when 7.4.1 is released
+  analyzer: 7.3.0
   analyzer_plugin: ^0.13.0
   archive: ^4.0.4
   args: ^2.4.2


### PR DESCRIPTION
v7.4.0 seems to have broken a lot. Upgrade when fixed and when a full element v2 migration can be completed.