### PR TITLE
chore(cli): Use distroless Docker containers

### DIFF
--- a/apps/distroless/flutter/build/Dockerfile
+++ b/apps/distroless/flutter/build/Dockerfile
@@ -111,5 +111,5 @@ COPY --from=build-engine /flutter/engine/src/out/host_release/flutter_tester flu
 WORKDIR /app
 COPY flutter_assets .
 
-ENTRYPOINT [ "/celest/flutter_runner", "--non-interactive", "--run-forever", "--disable-vm-service", "--icu-data-file-path=/celest/icudtl.dat", "--verbose-logging", "--enable-platform-isolates", "--force-multithreading", "--cache-dir-path=/tmp", "--flutter-assets-dir=/app/flutter_assets" ]
+ENTRYPOINT [ "/celest/flutter_runner", "--non-interactive", "--run-forever", "--disable-vm-service", "--icu-data-file-path=/celest/icudtl.dat", "--enable-platform-isolates", "--force-multithreading", "--cache-dir-path=/tmp", "--flutter-assets-dir=/app/flutter_assets" ]
 CMD [ "/app/main.aot" ]

--- a/apps/distroless/flutter/build/Dockerfile.old
+++ b/apps/distroless/flutter/build/Dockerfile.old
@@ -116,5 +116,5 @@ COPY --from=build-engine /engine/src/out/host_release/*.so* ./
 COPY --from=build-engine /engine/src/out/host_release/flutter_tester flutter_runner
 COPY flutter_assets .
 
-ENTRYPOINT [ "/app/flutter_runner", "--non-interactive", "--run-forever", "--disable-vm-service", "--icu-data-file-path=/app/icudtl.dat", "--verbose-logging", "--enable-platform-isolates", "--force-multithreading", "--cache-dir-path=/tmp", "--flutter-assets-dir=/app/flutter_assets" ]
+ENTRYPOINT [ "/app/flutter_runner", "--non-interactive", "--run-forever", "--disable-vm-service", "--icu-data-file-path=/app/icudtl.dat", "--enable-platform-isolates", "--force-multithreading", "--cache-dir-path=/tmp", "--flutter-assets-dir=/app/flutter_assets" ]
 CMD [ "/app/main.aot" ]


### PR DESCRIPTION
When creating a Dockerfile with `celest build`, use the distroless Dart + Flutter docker containers for quicker and more reliable images.