### PR TITLE
release(cli): v1.0.10

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.10
+
+- feat: Add templates to `celest init`
+- feat: Add `celest status` command
+- chore: Update to analyzer model v2
+- chore: Use distroless Docker base images
+
 ## 1.0.9
 
 - feat: Re-implement `celest upgrade`

--- a/apps/cli/fixtures/standalone/api/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/api/goldens/ast.json
@@ -33713,7 +33713,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/api/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/api/goldens/ast.resolved.json
@@ -3612,7 +3612,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/api/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/api/goldens/celest.json
@@ -3395,7 +3395,7 @@
       "major": 1,
       "minor": 0,
       "patch": 9,
-      "canonicalizedVersion": "1.0.9"
+      "canonicalizedVersion": "1.0.10"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/auth/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/ast.json
@@ -2143,7 +2143,7 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/auth/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/ast.resolved.json
@@ -605,7 +605,7 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/auth/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/celest.json
@@ -614,7 +614,7 @@
       "major": 1,
       "minor": 0,
       "patch": 9,
-      "canonicalizedVersion": "1.0.9"
+      "canonicalizedVersion": "1.0.10"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/data/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/data/goldens/ast.json
@@ -740,7 +740,7 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/data/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/data/goldens/ast.resolved.json
@@ -211,7 +211,7 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/data/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/data/goldens/celest.json
@@ -200,8 +200,8 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 9,
-      "canonicalizedVersion": "1.0.9"
+      "patch": 10,
+      "canonicalizedVersion": "1.0.10"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/env_vars/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/ast.json
@@ -827,7 +827,7 @@
   ],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/env_vars/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/ast.resolved.json
@@ -91,7 +91,7 @@
   ],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/env_vars/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/celest.json
@@ -96,7 +96,7 @@
       "major": 1,
       "minor": 0,
       "patch": 9,
-      "canonicalizedVersion": "1.0.9"
+      "canonicalizedVersion": "1.0.10"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/exceptions/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/ast.json
@@ -1313,7 +1313,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/exceptions/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/ast.resolved.json
@@ -187,7 +187,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/exceptions/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/celest.json
@@ -180,7 +180,7 @@
       "major": 1,
       "minor": 0,
       "patch": 9,
-      "canonicalizedVersion": "1.0.9"
+      "canonicalizedVersion": "1.0.10"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/flutter/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/ast.json
@@ -1105,7 +1105,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/flutter/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/ast.resolved.json
@@ -86,7 +86,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/flutter/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/celest.json
@@ -85,7 +85,7 @@
       "major": 1,
       "minor": 0,
       "patch": 9,
-      "canonicalizedVersion": "1.0.9"
+      "canonicalizedVersion": "1.0.10"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/http/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/http/goldens/ast.json
@@ -4933,7 +4933,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/http/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/http/goldens/ast.resolved.json
@@ -251,7 +251,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/http/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/http/goldens/celest.json
@@ -241,7 +241,7 @@
       "major": 1,
       "minor": 0,
       "patch": 9,
-      "canonicalizedVersion": "1.0.9"
+      "canonicalizedVersion": "1.0.10"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/marcelo/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/ast.json
@@ -1617,7 +1617,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/marcelo/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/ast.resolved.json
@@ -230,7 +230,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/marcelo/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/celest.json
@@ -220,7 +220,7 @@
       "major": 1,
       "minor": 0,
       "patch": 9,
-      "canonicalizedVersion": "1.0.9"
+      "canonicalizedVersion": "1.0.10"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/streaming/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/ast.json
@@ -525,7 +525,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/streaming/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/ast.resolved.json
@@ -86,7 +86,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.9",
+    "celest": "1.0.10",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/streaming/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/celest.json
@@ -83,7 +83,7 @@
       "major": 1,
       "minor": 0,
       "patch": 9,
-      "canonicalizedVersion": "1.0.9"
+      "canonicalizedVersion": "1.0.10"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/lib/src/version.dart
+++ b/apps/cli/lib/src/version.dart
@@ -1,7 +1,7 @@
 import 'package:celest_cli/src/utils/run.dart';
 import 'package:pub_semver/pub_semver.dart';
 
-const String _version = '1.0.9';
+const String _version = '1.0.10';
 
 final String packageVersion = run(() {
   const override = String.fromEnvironment('celest.version');

--- a/apps/cli/pubspec.yaml
+++ b/apps/cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: celest_cli
 description: The command-line interface for Celest.
-version: 1.0.9
+version: 1.0.10
 homepage: https://celest.dev
 repository: https://github.com/celest-dev/celest/tree/main/apps/cli
 


### PR DESCRIPTION
- feat: Add templates to `celest init`
- feat: Add `celest status` command
- chore: Update to analyzer model v2
- chore: Use distroless Docker base images