### PR TITLE
fix(cli): Init types on reset

### DIFF
--- a/apps/cli/lib/src/types/type_helper.dart
+++ b/apps/cli/lib/src/types/type_helper.dart
@@ -524,6 +524,7 @@ final class TypeHelper {
     serializationVerdicts.clear();
     subtypes.clear();
     overrides.clear();
+    init();
   }
 }
 


### PR DESCRIPTION
Accidentally deleted this line in analyzer v2 migration.