### PR TITLE
fix: Pass `flutter_assets` to backend during deploy

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+- fix: Pass `flutter_assets` to backend when using `celest deploy`
+
 ## 1.0.10+2
 
 - chore: Add back Sentry integration

--- a/apps/cli/fixtures/standalone/flutter/client/lib/flutter_client.dart
+++ b/apps/cli/fixtures/standalone/flutter/client/lib/flutter_client.dart
@@ -27,7 +27,7 @@ enum CelestEnvironment {
         local => _$celest.kIsWeb || !Platform.isAndroid
             ? Uri.parse('http://localhost:7777')
             : Uri.parse('http://10.0.2.2:7777'),
-        production => Uri.parse('https://example.celest.run'),
+        production => Uri.parse('https://flutter-7a0b5b.fly.dev'),
       };
 }
 

--- a/packages/celest_cloud/CHANGELOG.md
+++ b/packages/celest_cloud/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.7-wip
+
+- feat: Add `ProjectAsset.FLUTTER_ASSETS`
+
 # 0.1.6
 
 - feat: Add `ProjectEnvironment.uri` field

--- a/packages/celest_cloud/lib/src/proto/celest/cloud/v1alpha1/project_environments.pbenum.dart
+++ b/packages/celest_cloud/lib/src/proto/celest/cloud/v1alpha1/project_environments.pbenum.dart
@@ -19,10 +19,13 @@ class ProjectAsset_Type extends $pb.ProtobufEnum {
       ProjectAsset_Type._(0, _omitEnumNames ? '' : 'TYPE_UNSPECIFIED');
   static const ProjectAsset_Type DART_KERNEL =
       ProjectAsset_Type._(1, _omitEnumNames ? '' : 'DART_KERNEL');
+  static const ProjectAsset_Type FLUTTER_ASSETS =
+      ProjectAsset_Type._(2, _omitEnumNames ? '' : 'FLUTTER_ASSETS');
 
   static const $core.List<ProjectAsset_Type> values = <ProjectAsset_Type>[
     TYPE_UNSPECIFIED,
     DART_KERNEL,
+    FLUTTER_ASSETS,
   ];
 
   static final $core.Map<$core.int, ProjectAsset_Type> _byValue =

--- a/packages/celest_cloud/lib/src/proto/celest/cloud/v1alpha1/project_environments.pbjson.dart
+++ b/packages/celest_cloud/lib/src/proto/celest/cloud/v1alpha1/project_environments.pbjson.dart
@@ -350,6 +350,7 @@ const ProjectAsset_Type$json = {
   '2': [
     {'1': 'TYPE_UNSPECIFIED', '2': 0},
     {'1': 'DART_KERNEL', '2': 1},
+    {'1': 'FLUTTER_ASSETS', '2': 2},
   ],
 };
 
@@ -357,8 +358,9 @@ const ProjectAsset_Type$json = {
 final $typed_data.Uint8List projectAssetDescriptor = $convert.base64Decode(
     'CgxQcm9qZWN0QXNzZXQSQQoEdHlwZRgBIAEoDjIoLmNlbGVzdC5jbG91ZC52MWFscGhhMS5Qcm'
     '9qZWN0QXNzZXQuVHlwZUID4EECUgR0eXBlEh8KCGZpbGVuYW1lGAIgASgJQgPgQQJSCGZpbGVu'
-    'YW1lEhgKBmlubGluZRgDIAEoDEgAUgZpbmxpbmUSFwoEZXRhZxgEIAEoCUID4EECUgRldGFnIi'
-    '0KBFR5cGUSFAoQVFlQRV9VTlNQRUNJRklFRBAAEg8KC0RBUlRfS0VSTkVMEAFCBwoFYXNzZXQ=');
+    'YW1lEhgKBmlubGluZRgDIAEoDEgAUgZpbmxpbmUSFwoEZXRhZxgEIAEoCUID4EECUgRldGFnIk'
+    'EKBFR5cGUSFAoQVFlQRV9VTlNQRUNJRklFRBAAEg8KC0RBUlRfS0VSTkVMEAESEgoORkxVVFRF'
+    'Ul9BU1NFVFMQAkIHCgVhc3NldA==');
 
 @$core.Deprecated('Use deployProjectEnvironmentRequestDescriptor instead')
 const DeployProjectEnvironmentRequest$json = {

--- a/packages/celest_cloud/pubspec.yaml
+++ b/packages/celest_cloud/pubspec.yaml
@@ -1,6 +1,6 @@
 name: celest_cloud
 description: API contracts and Dart clients for the Celest Cloud platform.
-version: 0.1.6
+version: 0.1.7-wip
 repository: https://github.com/celest-dev/celest
 
 environment:

--- a/proto/celest/cloud/v1alpha1/project_environments.proto
+++ b/proto/celest/cloud/v1alpha1/project_environments.proto
@@ -347,6 +347,9 @@ message ProjectAsset {
 
     // The asset is a Dart kernel file.
     DART_KERNEL = 1;
+
+    // The asset is a flutter_assets bundle.
+    FLUTTER_ASSETS = 2;
   }
 
   // The type of the asset.

--- a/services/celest_cloud_hub/pubspec.yaml
+++ b/services/celest_cloud_hub/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 resolution: workspace
 
 dependencies:
+  archive: ^4.0.6
   async: ^2.13.0
   cedar: ^0.2.4
   celest: ^1.0.0


### PR DESCRIPTION
When deploying Flutter projects to the cloud, ensure that the `flutter_assets` dir is passed to the backend as well.