### PR TITLE
release(cli): v1.0.10+3

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 1.0.10+3
 
 - fix: Pass `flutter_assets` to backend when using `celest deploy`
 - fix: Sentry integration

--- a/apps/cli/lib/src/version.dart
+++ b/apps/cli/lib/src/version.dart
@@ -1,7 +1,7 @@
 import 'package:celest_cli/src/utils/run.dart';
 import 'package:pub_semver/pub_semver.dart';
 
-const String _version = '1.0.10+2';
+const String _version = '1.0.10+3';
 
 final String packageVersion = run(() {
   const override = String.fromEnvironment('celest.version');

--- a/apps/cli/pubspec.yaml
+++ b/apps/cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: celest_cli
 description: The command-line interface for Celest.
-version: 1.0.10+2
+version: 1.0.10+3
 homepage: https://celest.dev
 repository: https://github.com/celest-dev/celest/tree/main/apps/cli
 


### PR DESCRIPTION
- fix: Pass `flutter_assets` to backend when using `celest deploy`
- fix: Sentry integration
- fix: Ensure pub cache is fixed during startup