### PR TITLE
chore(celest): Migrate analyzer plugin to v2

### DIFF
--- a/packages/celest/CHANGELOG.md
+++ b/packages/celest/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.0.5-wip
+## 1.0.5
 
 - chore: Remove GCP mentions
+- chore: Update analyzer plugin to v2 model
 
 ## 1.0.4
 

--- a/packages/celest/tools/analyzer_plugin/lib/celest_analyzer_plugin.dart
+++ b/packages/celest/tools/analyzer_plugin/lib/celest_analyzer_plugin.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/analysis/uri_converter.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:analyzer/source/source_range.dart';
@@ -275,7 +275,8 @@ final class CelestNavigationContributor implements NavigationContributor {
       'computeNavigation Target node: $targetNode '
       '(${targetNode.runtimeType})',
     );
-    final libraryPath = request.result.libraryElement.source.fullName;
+    final libraryPath =
+        request.result.libraryElement2.firstFragment.source.fullName;
     _logger.info('computeNavigation Library path: $libraryPath');
     final visitor = NavigationVisitor(
       collector,
@@ -309,15 +310,14 @@ final class NavigationVisitor extends RecursiveAstVisitor<void> {
       return;
     }
 
-    final element = methodInvocation.methodName.staticElement;
-    if (element is! MethodElement) {
+    final element = methodInvocation.methodName.element;
+    if (element is! MethodElement2) {
       _logger.severe('Unexpected element: $element (${element.runtimeType})');
       return;
     }
     _logger.info('Element: $element (${element.runtimeType})');
-    final cloudFunctionAnnotation = element.metadata.firstWhereOrNull(
-      (annotation) => annotation.isCloudFunction,
-    );
+    final cloudFunctionAnnotation = element.metadata2.annotations
+        .firstWhereOrNull((annotation) => annotation.isCloudFunction);
     if (cloudFunctionAnnotation == null) {
       _logger.warning('CloudFunction annotation not found');
       return;

--- a/packages/celest/tools/analyzer_plugin/lib/src/analyzer_helpers.dart
+++ b/packages/celest/tools/analyzer_plugin/lib/src/analyzer_helpers.dart
@@ -1,10 +1,10 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/source/source_range.dart';
 
-extension ElementHelper on Element {
+extension ElementHelper on Element2 {
   /// Whether the source of this element is a package from the Celest SDK.
-  bool get isPackageCelest => switch (library?.source.uri) {
+  bool get isPackageCelest => switch (library2?.firstFragment.source.uri) {
         Uri(scheme: 'package', pathSegments: [final packageName, ...]) =>
           packageName.startsWith('celest') && packageName != 'celest_backend',
         _ => false,
@@ -14,9 +14,9 @@ extension ElementHelper on Element {
 extension AnnotationHelper on ElementAnnotation {
   /// Whether the element targeted by this annotation is the `CloudFunction`
   /// class from `package:celest`.
-  bool get isCloudFunction => switch (element) {
-        ConstructorElement(enclosingElement3: final classElement) =>
-          classElement.isPackageCelest && classElement.name == 'CloudFunction',
+  bool get isCloudFunction => switch (element2) {
+        ConstructorElement2(enclosingElement2: final classElement) =>
+          classElement.isPackageCelest && classElement.name3 == 'CloudFunction',
         _ => false,
       };
 }

--- a/packages/celest/tools/analyzer_plugin/pubspec.yaml
+++ b/packages/celest/tools/analyzer_plugin/pubspec.yaml
@@ -3,17 +3,16 @@ description: A plugin for the Dart analyzer that provides support for Celest bac
 publish_to: none
 
 environment: 
-  sdk: ^3.4.0
+  sdk: ^3.5.0
+resolution: workspace
 
 dependencies: 
-  analyzer: ^6.5.0
-  analyzer_plugin: ^0.11.3
+  analyzer: ^7.4.0
+  analyzer_plugin: ^0.13.0
   collection: ^1.18.0
   logging: ^1.2.0
   meta: ^1.12.0
-  package_config: ^2.1.0
   path: ^1.9.0
-  pubspec_parse: ^1.3.0
   source_span: ^1.10.0
   stack_trace: ^1.12.0
   yaml: ^3.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 workspace:
   - apps/cli
   - packages/celest
+  - packages/celest/tools/analyzer_plugin
   - packages/celest_ast
   - packages/celest_auth
   - packages/celest_cloud


### PR DESCRIPTION
Migrates the bundled analyzer plugin to the v2 element model.