### PR TITLE
chore: Bump `web_socket` dependency

### DIFF
--- a/packages/celest_core/CHANGELOG.md
+++ b/packages/celest_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3-wip
+
+- chore: Update dependencies
+
 ## 1.0.2
 
 - chore: Update license

--- a/packages/celest_core/pubspec.yaml
+++ b/packages/celest_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: celest_core
 description: Celest types and utilities shared between the client and the cloud.
-version: 1.0.2
+version: 1.0.3-wip
 homepage: https://celest.dev
 repository: https://github.com/celest-dev/celest/tree/main/packages/celest_core
 
@@ -25,7 +25,7 @@ dependencies:
   protobuf: ^3.0.0
   stream_channel: ^2.1.2
   web: ^1.0.0
-  web_socket: ^0.1.0
+  web_socket: '>=0.1.6 <2.0.0'
   web_socket_channel: ^3.0.0
 
 dev_dependencies:

--- a/packages/celest_test/CHANGELOG.md
+++ b/packages/celest_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1-wip
+
+- chore: Update dependencies
+
 ## 0.1.0
 
 - Initial version.

--- a/packages/celest_test/pubspec.yaml
+++ b/packages/celest_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: celest_test
 description: Helper package for running integration tests with Celest.
-version: 0.1.0
+version: 0.1.1-wip
 homepage: https://celest.dev
 repository: https://github.com/celest-dev/celest/tree/main/packages/celest_test
 
@@ -14,7 +14,7 @@ dependencies:
   logging: ^1.3.0
   test: ^1.25.15
   vm_service: '>=14.0.0 <16.0.0'
-  web_socket: ^0.1.6
+  web_socket: '>=0.1.6 <2.0.0'
 
 dev_dependencies:
   celest_lints: ^1.0.0


### PR DESCRIPTION
No breaking changes so allow pre-v1 versions as well.