### PR TITLE
release(cli): v1.0.10+3

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,8 +1,9 @@
-## NEXT
+## 1.0.10+3
 
 - fix: Pass `flutter_assets` to backend when using `celest deploy`
 - fix: Sentry integration
 - fix: Ensure pub cache is fixed during startup
+- fix: Fix project name in status command
 
 ## 1.0.10+2
 

--- a/apps/cli/fixtures/standalone/api/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/api/goldens/ast.json
@@ -33713,7 +33713,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/api/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/api/goldens/ast.resolved.json
@@ -3612,7 +3612,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/api/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/api/goldens/celest.json
@@ -3394,8 +3394,11 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 9,
-      "canonicalizedVersion": "1.0.10+2"
+      "patch": 10,
+      "build": [
+        3.0
+      ],
+      "canonicalizedVersion": "1.0.10+3"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/auth/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/ast.json
@@ -2067,7 +2067,7 @@
           "url": "package:celest_cloud_auth/src/database/auth_database.dart",
           "isNullable": false
         },
-        "version": 4,
+        "version": 5,
         "location": {
           "start": {
             "offset": 423,
@@ -2143,7 +2143,7 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/auth/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/ast.resolved.json
@@ -587,7 +587,7 @@
       "schema": {
         "$": "ResolvedDriftDatabaseSchema",
         "databaseSchemaId": "CloudAuthDatabase",
-        "version": 4,
+        "version": 5,
         "schemaJson": {},
         "type": "drift"
       },
@@ -605,7 +605,7 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/auth/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/celest.json
@@ -593,7 +593,7 @@
         "databaseSchemaId": "CloudAuthDatabase",
         "type": "DRIFT",
         "drift": {
-          "version": 4,
+          "version": 5,
           "schemaJson": {}
         }
       },
@@ -613,8 +613,11 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 9,
-      "canonicalizedVersion": "1.0.10+2"
+      "patch": 10,
+      "build": [
+        3.0
+      ],
+      "canonicalizedVersion": "1.0.10+3"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/data/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/data/goldens/ast.json
@@ -740,7 +740,7 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/data/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/data/goldens/ast.resolved.json
@@ -211,7 +211,7 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/data/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/data/goldens/celest.json
@@ -202,9 +202,9 @@
       "minor": 0,
       "patch": 10,
       "build": [
-        1.0
+        3.0
       ],
-      "canonicalizedVersion": "1.0.10+2"
+      "canonicalizedVersion": "1.0.10+3"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/env_vars/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/ast.json
@@ -827,7 +827,7 @@
   ],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/env_vars/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/ast.resolved.json
@@ -91,7 +91,7 @@
   ],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/env_vars/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/celest.json
@@ -95,8 +95,11 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 9,
-      "canonicalizedVersion": "1.0.10+2"
+      "patch": 10,
+      "build": [
+        3.0
+      ],
+      "canonicalizedVersion": "1.0.10+3"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/exceptions/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/ast.json
@@ -1313,7 +1313,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/exceptions/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/ast.resolved.json
@@ -187,7 +187,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/exceptions/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/celest.json
@@ -179,8 +179,11 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 9,
-      "canonicalizedVersion": "1.0.10+2"
+      "patch": 10,
+      "build": [
+        3.0
+      ],
+      "canonicalizedVersion": "1.0.10+3"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/flutter/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/ast.json
@@ -1105,7 +1105,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/flutter/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/ast.resolved.json
@@ -86,7 +86,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/flutter/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/celest.json
@@ -84,8 +84,11 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 9,
-      "canonicalizedVersion": "1.0.10+2"
+      "patch": 10,
+      "build": [
+        3.0
+      ],
+      "canonicalizedVersion": "1.0.10+3"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/http/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/http/goldens/ast.json
@@ -4933,7 +4933,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/http/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/http/goldens/ast.resolved.json
@@ -251,7 +251,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/http/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/http/goldens/celest.json
@@ -240,8 +240,11 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 9,
-      "canonicalizedVersion": "1.0.10+2"
+      "patch": 10,
+      "build": [
+        3.0
+      ],
+      "canonicalizedVersion": "1.0.10+3"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/marcelo/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/ast.json
@@ -1617,7 +1617,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/marcelo/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/ast.resolved.json
@@ -230,7 +230,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/marcelo/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/celest.json
@@ -219,8 +219,11 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 9,
-      "canonicalizedVersion": "1.0.10+2"
+      "patch": 10,
+      "build": [
+        3.0
+      ],
+      "canonicalizedVersion": "1.0.10+3"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/fixtures/standalone/streaming/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/ast.json
@@ -525,7 +525,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/streaming/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/ast.resolved.json
@@ -86,7 +86,7 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.10+2",
+    "celest": "1.0.10+3",
     "dart": {
       "type": "dart",
       "version": "3.7.2",

--- a/apps/cli/fixtures/standalone/streaming/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/celest.json
@@ -82,8 +82,11 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 9,
-      "canonicalizedVersion": "1.0.10+2"
+      "patch": 10,
+      "build": [
+        3.0
+      ],
+      "canonicalizedVersion": "1.0.10+3"
     },
     "dart": {
       "type": "DART",

--- a/apps/cli/lib/src/version.dart
+++ b/apps/cli/lib/src/version.dart
@@ -1,7 +1,7 @@
 import 'package:celest_cli/src/utils/run.dart';
 import 'package:pub_semver/pub_semver.dart';
 
-const String _version = '1.0.10+2';
+const String _version = '1.0.10+3';
 
 final String packageVersion = run(() {
   const override = String.fromEnvironment('celest.version');

--- a/apps/cli/pubspec.yaml
+++ b/apps/cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: celest_cli
 description: The command-line interface for Celest.
-version: 1.0.10+2
+version: 1.0.10+3
 homepage: https://celest.dev
 repository: https://github.com/celest-dev/celest/tree/main/apps/cli
 


### PR DESCRIPTION
- fix: Pass `flutter_assets` to backend when using `celest deploy`
- fix: Sentry integration
- fix: Ensure pub cache is fixed during startup