### PR TITLE
chore(distroless): Rename core image to celestdev/runtime

### DIFF
--- a/.github/workflows/distroless_core.yaml
+++ b/.github/workflows/distroless_core.yaml
@@ -51,7 +51,7 @@ jobs:
           file: apps/distroless/core/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: celestdev/core-builder:latest
+          tags: celestdev/runtime:latest
           cache-from: type=gha # Pull cache from GitHub Actions cache
           cache-to: type=gha,mode=max # Push cache to GitHub Actions cache (mode=max includes all layers)
 

--- a/apps/cli/lib/src/codegen/api/dockerfile_generator.dart
+++ b/apps/cli/lib/src/codegen/api/dockerfile_generator.dart
@@ -36,7 +36,7 @@ EXPOSE $PORT
   // TODO(dnys1): Remove `--platform=linux/amd64` when Celest supports arm64.
   static const String _dartExeTemplate = r'''
 # syntax=docker/dockerfile:1.2
-FROM --platform=linux/amd64 celestdev/core-runtime:latest
+FROM --platform=linux/amd64 celestdev/runtime:latest
 
 WORKDIR /app
 COPY --chmod=755 main.exe .


### PR DESCRIPTION
For consistency with other images