### PR TITLE
ci: Fix release workflow

### DIFF
--- a/.github/workflows/celest_cli.release.yaml
+++ b/.github/workflows/celest_cli.release.yaml
@@ -62,5 +62,5 @@ jobs:
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # 2.2.2
         with:
-          release_name: v${{ steps.bundle.outputs.version }}
-          files: ${{ join(fromJson(steps.bundle.outputs.artifacts), '\n') }}
+          name: v${{ steps.bundle.outputs.version }}
+          files: ${{ steps.bundle.outputs.artifacts }}

--- a/apps/cli/tool/release.dart
+++ b/apps/cli/tool/release.dart
@@ -82,8 +82,12 @@ Future<void> main(List<String> args) async {
 
   if (platform.environment['GITHUB_OUTPUT'] case final ciOutput?) {
     fileSystem.file(ciOutput).writeAsStringSync(
-          'version=$version\n'
-          'artifacts=${jsonEncode(artifacts)}\n',
+          [
+            'version=$version',
+            'artifacts<<EOF',
+            ...artifacts,
+            'EOF',
+          ].join('\n'),
           mode: FileMode.append,
           flush: true,
         );


### PR DESCRIPTION
join([...], '\n') does not in fact create a newline-delimited string...