### PR TITLE
chore(cli): Add Linux helper scripts

### DIFF
--- a/apps/cli/lib/src/cli/cli.dart
+++ b/apps/cli/lib/src/cli/cli.dart
@@ -95,12 +95,11 @@ final class Cli {
       await ctx.secureStorage.init();
     } on Object catch (e, st) {
       _logger.fine('Failed to initialize storage', e, st);
-      // TODO(dnys1): Need glib/gio linked on Linux.
       if (kReleaseMode) {
         if (ctx.platform.isLinux) {
           throw const CliException(
-            'libsecret is not installed. Please run `apt-get install libsecret-1-dev` '
-            'or equivalent before running Celest.',
+            'libsecret is not installed. Please run `apt-get install gnome-keyring libsecret-1-0` '
+            'or equivalent and ensure gnome-keyring-daemon is running before running Celest.',
           );
         }
         // This shouldn't happen in release mode, since permissioning should

--- a/apps/cli/tool/linux/celest
+++ b/apps/cli/tool/linux/celest
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# A helper script for running Celest in headless Linux environments.
+# 
+# This script configures the environment for running Celest and then executes the Celest binary.
+
+set -e
+
+OS=`uname -s`
+if test $OS = "Linux"; then
+    test -e /etc/os-release && os_release='/etc/os-release' || os_release='/usr/lib/os-release'
+    . "${os_release}"
+
+    if [ "${ID:-linux}" != "debian" ] && [ "${ID_LIKE#*debian*}" != "${ID_LIKE}" ]; then
+        >&2 echo "Unsupported distribution: ${ID:-linux}"
+        exit 1
+    fi
+
+    # If running in headless mode, re-run script in dbus session.
+    if ! dbus-send --session --dest=org.freedesktop.DBus / org.freedesktop.DBus.Peer.Ping > /dev/null 2>&1; then
+        exec dbus-run-session -- "$0" "$@"
+    fi
+
+    echo 'password' | gnome-keyring-daemon --start --replace --components=secrets --unlock --daemonize > /dev/null 2>&1
+fi
+
+celest $@

--- a/apps/cli/tool/linux/deb/DEBIAN/control
+++ b/apps/cli/tool/linux/deb/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: Celest
-Depends: gnome-keyring, libsecret-1-0, libsqlite3-dev
+Depends: gnome-keyring, libsecret-1-0, libsqlite3-0
 Version: {{ version }}
 Maintainer: Celest
 Architecture: {{ arch }}

--- a/apps/cli/tool/linux/install
+++ b/apps/cli/tool/linux/install
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# A script to install Celest CLI on Linux systems.
+
+set -e
+
+install_package() {
+    if [ "$(id -u)" -ne 0 ]; then
+        if ! command -v sudo &> /dev/null; then
+            echo "Script requires sudo to install gnome-keyring. Please install it manually."
+            exit 1
+        fi
+
+        sudo apt-get update
+        sudo apt-get install "${@}"
+    else
+        apt-get update
+        apt-get install "${@}"
+    fi
+}
+
+OS=`uname -s`
+case `uname -m` in
+    x86_64|amd64|AMD64)
+        ARCH="x64"
+        ;;
+    aarch64)
+        ARCH="arm64"
+        ;;
+    *)
+        >&2 echo "Unsupported architecture: $(uname -m)"
+        exit 1
+        ;;
+esac
+
+if test $OS = "Linux"; then
+    test -e /etc/os-release && os_release='/etc/os-release' || os_release='/usr/lib/os-release'
+    . "${os_release}"
+
+    if [ "${ID:-linux}" = "debian" ] || [ "${ID_LIKE#*debian*}" != "${ID_LIKE}" ]; then
+        echo "Detected Debian-based system: ${ID:-linux}"
+    else
+        >&2 echo "Unsupported distribution: ${ID:-linux}"
+        exit 1
+    fi
+
+    # Check if Celest is installed
+    if ! command -v celest &> /dev/null; then
+        if ! command -v curl &> /dev/null; then
+            echo "Installing curl..."
+            install_package -y curl
+        fi
+
+        echo "Installing Celest..."
+        CURRENT_DIR=$(pwd)
+        cd $(mktemp -d)
+        trap 'cd "$CURRENT_DIR"; rm -rf "$TMP_DIR"' EXIT
+
+        ARTIFACT_NAME="celest_cli-linux-${ARCH}.deb"
+        DOWNLOAD_URL="https://github.com/celest-dev/celest/releases/latest/download/$ARTIFACT_NAME"
+
+        echo "Downloading Celest from $DOWNLOAD_URL"
+        curl -sSLo "$ARTIFACT_NAME" "$DOWNLOAD_URL"
+        install_package -y --fix-broken "./$ARTIFACT_NAME"
+    fi
+fi
+
+echo "Celest is installed and ready to use."

--- a/apps/cli/tool/release.dart
+++ b/apps/cli/tool/release.dart
@@ -225,7 +225,11 @@ final class LinuxDebBundler extends Bundler {
         final outputControl = Template(
           controlFile.readAsStringSync(),
         ).renderString({
-          'arch': arch,
+          'arch': switch (arch) {
+            'arm64' => 'arm64',
+            'x64' => 'amd64',
+            _ => throw UnsupportedError('Unsupported arch: $arch'),
+          },
           'version': version,
         });
         print('Writing control contents:\n\n$outputControl\n');


### PR DESCRIPTION
- Adds `install` and `celest` scripts to simplify the installation of Celest CLI on Linux and the execution in headless environments.
- Updates Linux releases with proper deps and architecture