### PR TITLE
ci: Run e2e tests on smaller runners

### DIFF
--- a/.github/workflows/celest_cli.e2e.yaml
+++ b/.github/workflows/celest_cli.e2e.yaml
@@ -31,9 +31,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-large
-          - macos-latest-xlarge
-          - windows-large
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
ubuntu-large is super flaky for some reason and since these on run on commit (async) they don't need to be super fast