### PR TITLE
chore(cli): Update cross-compilation version

### DIFF
--- a/apps/cli/lib/src/compiler/api/entrypoint_compiler.dart
+++ b/apps/cli/lib/src/compiler/api/entrypoint_compiler.dart
@@ -75,7 +75,6 @@ final class EntrypointCompiler {
       if (Abi.current() != Abi.linuxX64) ...[
         '--target-os=linux',
         '--target-arch=x64',
-        '--experimental-cross-compilation',
       ],
       '-o',
       outputPath,

--- a/apps/cli/lib/src/sdk/dart_sdk.dart
+++ b/apps/cli/lib/src/sdk/dart_sdk.dart
@@ -223,8 +223,7 @@ class Sdk {
       );
 
   /// The version when cross-compilation was introduced.
-  static final Version _crossCompilationVersion =
-      Version.parse('3.8.0-262.0.dev');
+  static final Version _crossCompilationVersion = Version.parse('3.8.0');
 
   /// Whether or not the current SDK supports cross-compilation.
   bool get supportsCrossCompilation {


### PR DESCRIPTION
The `--experimental-cross-compilation` is removed for 3.8 stable so only allow 3.8 stable to avoid issues.