### PR TITLE
Add deep wiki support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,12 @@ Ensure that any changes made to a package have accompanying tests. To run tests 
 $ dart test
 ```
 
-Pull request titles should follow [convential commit](https://www.conventionalcommits.org/en/v1.0.0/) format `type(scope): Title` where `type` is the type of change being made (e.g. `feat`, `chore`, `refactor`, etc) and `scope` is the scope of the change (e.g. `auth`, `core`, or `repo` for repo-wide changes). 
+Pull request titles should follow [convential commit](https://www.conventionalcommits.org/en/v1.0.0/) format `type(scope): Title` where `type` is the type of change being made (e.g. `feat`, `chore`, `refactor`, etc) and `scope` is the scope of the change (e.g. `auth`, `core`, or `repo` for repo-wide changes).
 
 For example, a pull request that adds a new feature to Celest Auth should have a title like `feat(auth): Passkey management`.
+
+### Want to Learn More?
+
+An AI-generated overview of the project architecture is available at [deepWiki](https://deepwiki.com/celest-dev/celest/1-overview).
+The site includes an interactive chat assistant to help answer your questions.
+_Disclaimer: This tool is community-generated and not officially maintained by the Celest team._

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Celest is the Flutter cloud platform. We enable Flutter and Dart developers to declaratively define their backend infrastructure in Dart.
 
-And to stay up-to-date on the future of Celest, including full server-side rendered Flutter apps, join our newsletter at [celest.dev](https://www.celest.dev/#stay-up-to-date).
+And to stay up-to-date on the future of Celest, including full server-side rendered Flutter apps, join our newsletter at [celest.dev](https://www.celest.dev/#stay-up-to-date). You can also explore a comprehensive wiki about the project architecture at [deepWiki](https://deepwiki.com/celest-dev/celest/1-overview).
 
 ## Getting Started
 
@@ -27,6 +27,7 @@ Once you have the CLI installed, you can create a new project by running the fol
 ```bash
 $ celest init
 ```
+
 You can run this command from within your Flutter project which will create a new `celest/` directory for your project. Or you can run
 this in another directory to have a standalone Celest project.
 
@@ -37,10 +38,10 @@ $ celest start
 ✓ Celest is running on http://localhost:7777
 ```
 
-This command will start a local server which will run in the background as you write your backend logic. As you make changes to the files in the `celest/` directory, 
+This command will start a local server which will run in the background as you write your backend logic. As you make changes to the files in the `celest/` directory,
 the server will hot-reload those changes so you can see them live.
 
-To interact with the running environment, Celest will generate a Dart client which you can use in any Dart or Flutter project. This client 
+To interact with the running environment, Celest will generate a Dart client which you can use in any Dart or Flutter project. This client
 is generated in the `client/` directory of your `celest/` folder. As you make changes in the local environment, this client will be updated to reflect those changes.
 
 ### Example
@@ -71,7 +72,7 @@ Future<void> main() async {
 
 ## What's Next?
 
-In addition to Dart cloud functions, Celest offers authentication and database services out-of-the-box. To learn more about these features, 
+In addition to Dart cloud functions, Celest offers authentication and database services out-of-the-box. To learn more about these features,
 and to see what else you can do with cloud functions, visit our [docs](https://celest.dev/docs) and explore the different examples and
 packages available in this repo.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Celest is the Flutter cloud platform. We enable Flutter and Dart developers to declaratively define their backend infrastructure in Dart.
 
-And to stay up-to-date on the future of Celest, including full server-side rendered Flutter apps, join our newsletter at [celest.dev](https://www.celest.dev/#stay-up-to-date). You can also explore a comprehensive wiki about the project architecture at [deepWiki](https://deepwiki.com/celest-dev/celest/1-overview).
+And to stay up-to-date on the future of Celest, including full server-side rendered Flutter apps, join our newsletter at [celest.dev](https://www.celest.dev/#stay-up-to-date).
 
 ## Getting Started
 


### PR DESCRIPTION
**Description**
This PR aims to add a wiki documentation that a takes a deep dive into what the core architecture and proposition for Celest are. This is especially helpful to create an interactive environment for new contributors (like myself) to get started with contribution by having a deeper understanding of the project at its core. Enabling them to contribute quicker, and overall helps Celest ship faster.

_**Wiki screenshot:**_
<img width="1457" alt="image" src="https://github.com/user-attachments/assets/4a1ff452-4fcc-42d3-b622-1c770b0942f9" />