### PR TITLE
perf(cloud_auth): Use batches for migrations

### DIFF
--- a/services/celest_cloud_auth/CHANGELOG.md
+++ b/services/celest_cloud_auth/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.2+2
 
 - fix: Migration of Cloud Auth tables
+- perf: Use batches for migrations
 
 ## 0.3.2+1
 

--- a/services/celest_cloud_auth/lib/src/database/schema/cloud_auth_core.drift
+++ b/services/celest_cloud_auth/lib/src/database/schema/cloud_auth_core.drift
@@ -348,7 +348,7 @@ deleteCork:
     WHERE cork_id = :cork_id;
 
 -- Revokes all cloud_auth_corks under the given entity.
-deletecloud_auth_corksForEntity(
+deleteCorksForEntity(
     :bearer_type AS TEXT OR NULL,
     :bearer_id AS TEXT OR NULL,
     :audience_type AS TEXT OR NULL,

--- a/services/celest_cloud_auth/lib/src/database/schema/cloud_auth_core.drift.dart
+++ b/services/celest_cloud_auth/lib/src/database/schema/cloud_auth_core.drift.dart
@@ -2496,7 +2496,7 @@ class CloudAuthCoreDrift extends i7.ModularAccessor {
     );
   }
 
-  i8.Future<List<i2.Uint8List>> deletecloud_auth_corksForEntity(
+  i8.Future<List<i2.Uint8List>> deleteCorksForEntity(
       {String? bearerType,
       String? bearerId,
       String? audienceType,


### PR DESCRIPTION
When seeding the database or inserting entities across multiple tables, use batches to improve performance. This is required for Turso since transactions have short time limits and can easily timeout when not using batches.