### PR TITLE
chore(celest): Use context HTTP client for DB connections

### DIFF
--- a/packages/celest/lib/src/runtime/data/celest_database.dart
+++ b/packages/celest/lib/src/runtime/data/celest_database.dart
@@ -90,6 +90,7 @@ sealed class CelestDatabase<Database extends GeneratedDatabase> {
             },
           ),
           jwtToken: token,
+          httpClient: context.httpClient,
         );
         return LibsqlDatabase(
           uri: uri,

--- a/services/celest_cloud_hub/bin/cloud_hub.dart
+++ b/services/celest_cloud_hub/bin/cloud_hub.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:async/async.dart';
 import 'package:cedar/cedar.dart';
 import 'package:celest/celest.dart';
-import 'package:celest/src/runtime/data/connect.dart';
+import 'package:celest/src/runtime/data/celest_database.dart';
 import 'package:celest_cloud_auth/celest_cloud_auth.dart';
 import 'package:celest_cloud_auth/src/authorization/authorizer.dart';
 import 'package:celest_cloud_auth/src/authorization/corks_repository.dart';
@@ -100,12 +100,14 @@ Future<void> main() async {
 
 Future<void> _run() async {
   context.logger.config('Configuring Cloud Hub database');
-  final db = await connect(
+  final celestDb = await CelestDatabase.create(
     Context.current,
     name: 'CloudHubDatabase',
     factory: CloudHubDatabase.new,
     hostnameVariable: const env('CLOUD_HUB_DATABASE_HOST'),
     tokenSecret: const secret('CLOUD_HUB_DATABASE_TOKEN'),
+  );
+  final db = await celestDb.connect(
     setup: (db) => db.addHelperFunctions(),
     logStatements: context.logger.level <= Level.FINEST,
   );


### PR DESCRIPTION
To ensure that HTTP timeouts and retry behavior are centralized and overridable, use the context's HTTP client for Hrana connections.
