### PR TITLE
chore(core): Ensure DDC compilation

### DIFF
--- a/.github/workflows/celest_core.yaml
+++ b/.github/workflows/celest_core.yaml
@@ -47,6 +47,9 @@ jobs:
       - name: Test
         working-directory: packages/celest_core
         run: dart test
+      - name: Test (Chrome, ddc)
+        working-directory: packages/celest_core
+        run: dart run build_runner test --delete-conflicting-outputs -- -p chrome
       - name: Test (Chrome, dart2js)
         working-directory: packages/celest_core
         run: dart test -p chrome

--- a/packages/celest_core/lib/src/exception/cloud_exception.dart
+++ b/packages/celest_core/lib/src/exception/cloud_exception.dart
@@ -11,7 +11,7 @@ import 'package:celest_core/src/http/http_status.dart';
 import 'package:celest_core/src/proto/google/protobuf/struct.pb.dart';
 import 'package:celest_core/src/serialization/json_value.dart';
 import 'package:celest_core/src/util/json.dart';
-import 'package:grpc/grpc_or_grpcweb.dart' show StatusCode, GrpcError;
+import 'package:grpc/src/shared/status.dart' show StatusCode, GrpcError;
 import 'package:http/http.dart' as http show Response;
 import 'package:json_annotation/json_annotation.dart' show JsonKey;
 import 'package:meta/meta.dart' show protected;

--- a/packages/celest_core/pubspec.yaml
+++ b/packages/celest_core/pubspec.yaml
@@ -29,5 +29,8 @@ dependencies:
   web_socket_channel: ^3.0.0
 
 dev_dependencies:
+  build_runner: ^2.4.15
+  build_test: ^2.2.3
+  build_web_compilers: ^4.1.4
   celest_lints: ^1.0.0
   test: ^1.25.0

--- a/packages/celest_core/test/exception/cloud_exception_test.dart
+++ b/packages/celest_core/test/exception/cloud_exception_test.dart
@@ -1,0 +1,12 @@
+import 'package:celest_core/celest_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Tests that cloud exceptions can be created and thrown on VM/Web.
+  //
+  // We need to make sure that no `dart:io` imports are accidentally added.
+  test('CloudException', () {
+    const exception = CloudException.badRequest();
+    expect(exception, isA<BadRequestException>());
+  });
+}


### PR DESCRIPTION
The default gRPC import (`package:grpc/grpc_or_grpcweb.dart`) causes DDC to fail compilation. This adds tests to `celest_core` to ensure that it can imported and compiled on DDC.