### PR TITLE
chore(cli): Update goldens

### DIFF
--- a/.github/workflows/celest_cli.yaml
+++ b/.github/workflows/celest_cli.yaml
@@ -26,9 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-large
+          - macos-latest-xlarge
+          - windows-large
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30 # Windows is really slow
     steps:
@@ -40,7 +40,7 @@ jobs:
           cache: true
           # Because many golden tests encode the precise Dart/Flutter SDKs used to generate
           # them, these values must be consistently used when running tests locally and in CI.
-          flutter-version: 3.32.0-0.1.pre
+          flutter-version: 3.32.0-0.3.pre
           channel: beta
       - name: Setup Libsecret
         if: runner.os == 'Linux'

--- a/apps/cli/fixtures/fixtures_test.dart
+++ b/apps/cli/fixtures/fixtures_test.dart
@@ -47,7 +47,10 @@ void main() {
     _ => false,
   };
   final includeTests = Platform.environment['INCLUDE_TESTS']?.split(',');
-  final skipTests = Platform.environment['SKIP_TESTS']?.split(',');
+  final excludeTests = {
+    ...?Platform.environment['EXCLUDE_TESTS']?.split(','),
+    'flutter', // TODO(dnys1): Re-enable on stable release
+  };
   final includeApis = Platform.environment['INCLUDE_APIS']?.split(',');
   final clearCache = Platform.environment['CLEAR_CACHE'] == 'true';
 
@@ -80,7 +83,7 @@ void main() {
         !includeTests.contains(p.basename(testDir.path))) {
       continue;
     }
-    if (skipTests != null && skipTests.contains(p.basename(testDir.path))) {
+    if (excludeTests.contains(p.basename(testDir.path))) {
       continue;
     }
     final testRunner = TestRunner(

--- a/apps/cli/fixtures/standalone/api/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/api/goldens/ast.json
@@ -33716,7 +33716,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -33725,7 +33725,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/api/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/api/goldens/ast.resolved.json
@@ -3615,7 +3615,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -3624,7 +3624,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/api/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/api/goldens/celest.json
@@ -3405,10 +3405,10 @@
         "patch": 0,
         "preRelease": [
           278.0,
-          1.0,
+          2.0,
           "beta"
         ],
-        "canonicalizedVersion": "3.8.0-278.1.beta"
+        "canonicalizedVersion": "3.8.0-278.2.beta"
       }
     },
     "flutter": {
@@ -3419,10 +3419,10 @@
         "patch": 0,
         "preRelease": [
           0.0,
-          1.0,
+          3.0,
           "pre"
         ],
-        "canonicalizedVersion": "3.32.0-0.1.pre"
+        "canonicalizedVersion": "3.32.0-0.3.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/auth/.env.local
+++ b/apps/cli/fixtures/standalone/auth/.env.local
@@ -1,1 +1,0 @@
-SUPABASE_URL=https://vduqtbtlcxxozghvhdqu.supabase.co

--- a/apps/cli/fixtures/standalone/auth/.firebaserc
+++ b/apps/cli/fixtures/standalone/auth/.firebaserc
@@ -1,7 +1,0 @@
-{
-  "projects": {
-    "local": "prj-d-firebase-test"
-  },
-  "targets": {},
-  "etags": {}
-}

--- a/apps/cli/fixtures/standalone/auth/client/pubspec.yaml
+++ b/apps/cli/fixtures/standalone/auth/client/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 
 dependencies:
   celest: ^1.0.0
+  celest_auth: ^1.0.0
   celest_backend:
     path: ..
   celest_core: ^1.0.0

--- a/apps/cli/fixtures/standalone/auth/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/ast.json
@@ -2146,16 +2146,16 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
-    "targetSdk": "flutter",
+    "targetSdk": "dart",
     "featureFlags": [
       "streaming"
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/auth/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/ast.resolved.json
@@ -620,10 +620,6 @@
   },
   "variables": [
     {
-      "name": "SUPABASE_URL",
-      "value": "https://vduqtbtlcxxozghvhdqu.supabase.co"
-    },
-    {
       "name": "CELEST_ENVIRONMENT",
       "value": "local"
     }
@@ -656,16 +652,16 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
-    "targetSdk": "flutter",
+    "targetSdk": "dart",
     "featureFlags": [
       "streaming"
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/auth/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/celest.json
@@ -611,10 +611,6 @@
   },
   "variables": [
     {
-      "name": "SUPABASE_URL",
-      "value": "https://vduqtbtlcxxozghvhdqu.supabase.co"
-    },
-    {
       "name": "CELEST_ENVIRONMENT",
       "value": "local"
     }
@@ -667,10 +663,10 @@
         "patch": 0,
         "preRelease": [
           278.0,
-          1.0,
+          2.0,
           "beta"
         ],
-        "canonicalizedVersion": "3.8.0-278.1.beta"
+        "canonicalizedVersion": "3.8.0-278.2.beta"
       }
     },
     "flutter": {
@@ -681,13 +677,13 @@
         "patch": 0,
         "preRelease": [
           0.0,
-          1.0,
+          3.0,
           "pre"
         ],
-        "canonicalizedVersion": "3.32.0-0.1.pre"
+        "canonicalizedVersion": "3.32.0-0.3.pre"
       }
     },
-    "targetSdk": "FLUTTER",
+    "targetSdk": "DART",
     "featureFlags": [
       "STREAMING"
     ]

--- a/apps/cli/fixtures/standalone/auth/pubspec.yaml
+++ b/apps/cli/fixtures/standalone/auth/pubspec.yaml
@@ -6,14 +6,10 @@ environment:
 
 dependencies:
   celest: ^1.0.0
-  celest_cloud_auth: 'any'
+  celest_cloud_auth: ^0.3.0-0
   celest_core: ^1.0.0
   drift_hrana: ^1.0.5
-  firebase_auth: ^5.3.1
-  gotrue: ^2.9.0
   meta: ^1.12.0
-  shelf: ^1.4.1
-  stream_transform: ^2.1.0
 
 dependency_overrides:
   celest:

--- a/apps/cli/fixtures/standalone/data/client/pubspec.yaml
+++ b/apps/cli/fixtures/standalone/data/client/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 
 dependencies:
   celest: ^1.0.0
+  celest_auth: ^1.0.0
   celest_backend:
     path: ..
   celest_core: ^1.0.0

--- a/apps/cli/fixtures/standalone/data/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/data/goldens/ast.json
@@ -725,7 +725,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -734,7 +734,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/data/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/data/goldens/ast.resolved.json
@@ -262,7 +262,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -271,7 +271,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/data/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/data/goldens/celest.json
@@ -254,10 +254,10 @@
         "patch": 0,
         "preRelease": [
           278.0,
-          1.0,
+          2.0,
           "beta"
         ],
-        "canonicalizedVersion": "3.8.0-278.1.beta"
+        "canonicalizedVersion": "3.8.0-278.2.beta"
       }
     },
     "flutter": {
@@ -268,10 +268,10 @@
         "patch": 0,
         "preRelease": [
           0.0,
-          1.0,
+          3.0,
           "pre"
         ],
-        "canonicalizedVersion": "3.32.0-0.1.pre"
+        "canonicalizedVersion": "3.32.0-0.3.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/env_vars/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/ast.json
@@ -830,7 +830,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -839,7 +839,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/env_vars/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/ast.resolved.json
@@ -94,7 +94,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -103,7 +103,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/env_vars/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/celest.json
@@ -106,10 +106,10 @@
         "patch": 0,
         "preRelease": [
           278.0,
-          1.0,
+          2.0,
           "beta"
         ],
-        "canonicalizedVersion": "3.8.0-278.1.beta"
+        "canonicalizedVersion": "3.8.0-278.2.beta"
       }
     },
     "flutter": {
@@ -120,10 +120,10 @@
         "patch": 0,
         "preRelease": [
           0.0,
-          1.0,
+          3.0,
           "pre"
         ],
-        "canonicalizedVersion": "3.32.0-0.1.pre"
+        "canonicalizedVersion": "3.32.0-0.3.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/exceptions/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/ast.json
@@ -1316,7 +1316,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -1325,7 +1325,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/exceptions/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/ast.resolved.json
@@ -190,7 +190,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -199,7 +199,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/exceptions/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/celest.json
@@ -190,10 +190,10 @@
         "patch": 0,
         "preRelease": [
           278.0,
-          1.0,
+          2.0,
           "beta"
         ],
-        "canonicalizedVersion": "3.8.0-278.1.beta"
+        "canonicalizedVersion": "3.8.0-278.2.beta"
       }
     },
     "flutter": {
@@ -204,10 +204,10 @@
         "patch": 0,
         "preRelease": [
           0.0,
-          1.0,
+          3.0,
           "pre"
         ],
-        "canonicalizedVersion": "3.32.0-0.1.pre"
+        "canonicalizedVersion": "3.32.0-0.3.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/http/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/http/goldens/ast.json
@@ -4936,7 +4936,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -4945,7 +4945,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/http/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/http/goldens/ast.resolved.json
@@ -254,7 +254,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -263,7 +263,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/http/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/http/goldens/celest.json
@@ -251,10 +251,10 @@
         "patch": 0,
         "preRelease": [
           278.0,
-          1.0,
+          2.0,
           "beta"
         ],
-        "canonicalizedVersion": "3.8.0-278.1.beta"
+        "canonicalizedVersion": "3.8.0-278.2.beta"
       }
     },
     "flutter": {
@@ -265,10 +265,10 @@
         "patch": 0,
         "preRelease": [
           0.0,
-          1.0,
+          3.0,
           "pre"
         ],
-        "canonicalizedVersion": "3.32.0-0.1.pre"
+        "canonicalizedVersion": "3.32.0-0.3.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/marcelo/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/ast.json
@@ -1620,7 +1620,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -1629,7 +1629,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/marcelo/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/ast.resolved.json
@@ -233,7 +233,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -242,7 +242,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/marcelo/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/celest.json
@@ -230,10 +230,10 @@
         "patch": 0,
         "preRelease": [
           278.0,
-          1.0,
+          2.0,
           "beta"
         ],
-        "canonicalizedVersion": "3.8.0-278.1.beta"
+        "canonicalizedVersion": "3.8.0-278.2.beta"
       }
     },
     "flutter": {
@@ -244,10 +244,10 @@
         "patch": 0,
         "preRelease": [
           0.0,
-          1.0,
+          3.0,
           "pre"
         ],
-        "canonicalizedVersion": "3.32.0-0.1.pre"
+        "canonicalizedVersion": "3.32.0-0.3.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/streaming/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/ast.json
@@ -528,7 +528,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -537,7 +537,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/streaming/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/ast.resolved.json
@@ -89,7 +89,7 @@
     "celest": "1.0.12",
     "dart": {
       "type": "dart",
-      "version": "3.8.0-278.1.beta",
+      "version": "3.8.0-278.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -98,7 +98,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.32.0-0.1.pre",
+      "version": "3.32.0-0.3.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/streaming/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/celest.json
@@ -93,10 +93,10 @@
         "patch": 0,
         "preRelease": [
           278.0,
-          1.0,
+          2.0,
           "beta"
         ],
-        "canonicalizedVersion": "3.8.0-278.1.beta"
+        "canonicalizedVersion": "3.8.0-278.2.beta"
       }
     },
     "flutter": {
@@ -107,10 +107,10 @@
         "patch": 0,
         "preRelease": [
           0.0,
-          1.0,
+          3.0,
           "pre"
         ],
-        "canonicalizedVersion": "3.32.0-0.1.pre"
+        "canonicalizedVersion": "3.32.0-0.3.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/lib/src/codegen/client/categories/client_auth_generator.dart
+++ b/apps/cli/lib/src/codegen/client/categories/client_auth_generator.dart
@@ -9,6 +9,7 @@ import 'package:code_builder/code_builder.dart';
 
 final class ClientAuthGenerator {
   ClientAuthGenerator({required this.auth}) {
+    CodegenDependencies.current.add('celest_auth');
     _library = LibraryBuilder()
       ..name = ''
       ..comments.addAll(kClientHeader)

--- a/apps/cli/lib/src/pub/project_dependency.dart
+++ b/apps/cli/lib/src/pub/project_dependency.dart
@@ -65,6 +65,7 @@ final class ProjectDependency {
   static final Map<String, ProjectDependency> all = {
     celest.name: celest,
     celestAst.name: celestAst,
+    celestAuth.name: celestAuth,
     celestCloudAuth.name: celestCloudAuth,
     celestCore.name: celestCore,
     firebaseAuth.name: firebaseAuth,
@@ -91,6 +92,14 @@ final class ProjectDependency {
     DependencyType.dependency,
     HostedDependency(
       version: VersionConstraint.compatibleWith(Version.parse('0.1.0')),
+    ),
+  );
+
+  static final ProjectDependency celestAuth = ProjectDependency._(
+    'celest_auth',
+    DependencyType.dependency,
+    HostedDependency(
+      version: VersionConstraint.compatibleWith(currentMinorVersion),
     ),
   );
 


### PR DESCRIPTION
- Updates Flutter SDK to 3.32.0-0.3.pre
- Updates CLI goldens
- Adds `celest_auth` to client dependencies when using Celest Auth to prevent analyzer warnings