### PR TITLE
chore(distroless): Try to re-enable beta builds

### DIFF
--- a/apps/distroless/bin/list_sdks.dart
+++ b/apps/distroless/bin/list_sdks.dart
@@ -1,11 +1,16 @@
 import 'dart:convert';
 
 import 'package:distroless/src/sdk/sdk_manager.dart';
-import 'package:distroless/src/sdk/sdk_release_info.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 final Version minDartSdkVersion = Version(3, 7, 0);
 final Version minFlutterSdkVersion = Version(3, 29, 0);
+
+/// SDKs where the tagged Dart SDK version does not match the published one.
+final List<Version> badFlutterSdks = [
+  Version.parse('3.30.0-0.1.pre'),
+  Version.parse('3.31.0-0.1.pre'),
+];
 
 Future<void> main(List<String> args) async {
   final type = args.isNotEmpty ? args[0] : 'dart';
@@ -21,11 +26,13 @@ Future<void> main(List<String> args) async {
     allVersions.allReleases.entries.where((v) => v.key >= minVersion).toList()
       ..sort((a, b) => a.key.compareTo(b.key)),
   );
+  if (type == 'flutter') {
+    for (final version in badFlutterSdks) {
+      releases.remove(version);
+    }
+  }
   final versions =
       releases.entries
-          // TODO(dnys1): Only include stable releases for Flutter since beta
-          // SDKs create SDK hash mismatch errors.
-          .where((it) => type == 'dart' || it.value == SdkChannel.stable)
           .map((it) => {'version': it.key.toString(), 'channel': it.value.name})
           .toList();
 

--- a/apps/distroless/flutter/build/build.sh
+++ b/apps/distroless/flutter/build/build.sh
@@ -22,7 +22,7 @@ esac
     --no-rbe \
     --no-stripped \
     --verbose \
-    --no-prebuilt-dart-sdk \
+    --prebuilt-dart-sdk \
     --no-enable-unittests \
     --enable-fontconfig \
     --target-dir=host_release \

--- a/apps/distroless/flutter/build/sync.sh
+++ b/apps/distroless/flutter/build/sync.sh
@@ -28,6 +28,7 @@ solutions = [
       "download_esbuild": False,
       "download_android_deps": False,
       "download_fuchsia_deps": False,
+      "download_dart_sdk": True,
       "host_os": "linux",
       "host_cpu": "${ARCH}",
     }


### PR DESCRIPTION
Use prebuilt Dart SDK since the git revision of the /third_party version does not match the prebuilt which causes invalid SDK hash checks when testing against the downloaded Flutter SDK.