### PR TITLE
ci: Use XL macOS runners for integration tests

### DIFF
--- a/.github/workflows/celest.yaml
+++ b/.github/workflows/celest.yaml
@@ -62,7 +62,7 @@ jobs:
         run: dart test -p chrome -c dart2wasm
   test_darwin:
     needs: [test]
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     timeout-minutes: 20
     steps:
       - name: Git Checkout

--- a/.github/workflows/celest_auth.yaml
+++ b/.github/workflows/celest_auth.yaml
@@ -48,7 +48,7 @@ jobs:
       #   run: dart test
   test_darwin:
     needs: [test]
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     timeout-minutes: 20
     steps:
       - name: Git Checkout


### PR DESCRIPTION
The normal runners experience timeouts way too often.