### PR TITLE
chore(examples): Add dependency_override for celest_ast

### DIFF
--- a/examples/firebase/pubspec.yaml
+++ b/examples/firebase/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
 dependency_overrides:
   celest:
     path: ../../packages/celest
+  celest_ast:
+    path: ../../packages/celest_ast
   celest_auth:
     path: ../../packages/celest_auth
   celest_cloud:

--- a/examples/gemini/pubspec.yaml
+++ b/examples/gemini/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
 dependency_overrides:
   celest:
     path: ../../packages/celest
+  celest_ast:
+    path: ../../packages/celest_ast
   celest_auth:
     path: ../../packages/celest_auth
   celest_cloud:

--- a/examples/openai/pubspec.yaml
+++ b/examples/openai/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
 dependency_overrides:
   celest:
     path: ../../packages/celest
+  celest_ast:
+    path: ../../packages/celest_ast
   celest_auth:
     path: ../../packages/celest_auth
   celest_cloud:

--- a/examples/supabase/pubspec.yaml
+++ b/examples/supabase/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
 dependency_overrides:
   celest:
     path: ../../packages/celest
+  celest_ast:
+    path: ../../packages/celest_ast
   celest_auth:
     path: ../../packages/celest_auth
   celest_cloud:

--- a/examples/tasks/pubspec.yaml
+++ b/examples/tasks/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
 dependency_overrides:
   celest:
     path: ../../packages/celest
+  celest_ast:
+    path: ../../packages/celest_ast
   celest_auth:
     path: ../../packages/celest_auth
   celest_cloud:

--- a/packages/celest/example/pubspec.yaml
+++ b/packages/celest/example/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
 dependency_overrides:
   celest:
     path: ../
+  celest_ast:
+    path: ../../celest_ast
   celest_auth:
     path: ../../celest_auth
   celest_cloud:


### PR DESCRIPTION
So that dependency resolution works even when celest_ast hasn't been published yet.