### PR TITLE
chore(cli): `vm_platform_strong` renamed to `vm_platform`

### DIFF
--- a/apps/cli/lib/src/sdk/dart_sdk.dart
+++ b/apps/cli/lib/src/sdk/dart_sdk.dart
@@ -216,15 +216,35 @@ class Sdk {
             'platform_strong.dill',
           );
 
-  String get vmPlatformDill =>
-      p.absolute(sdkPath, 'lib', '_internal', 'vm_platform_strong.dill');
+  String get vmPlatformDill {
+    final dillPath = p.absolute(
+      sdkPath,
+      'lib',
+      '_internal',
+      'vm_platform_strong.dill',
+    );
+    if (_fileSystem.file(dillPath).existsSync()) {
+      return dillPath;
+    }
+    // In newer SDKs, `vm_platform_strong.dill` is replaced with
+    // `vm_platform.dill`.
+    return p.absolute(sdkPath, 'lib', '_internal', 'vm_platform.dill');
+  }
 
-  String get vmPlatformProductDill => p.absolute(
-    sdkPath,
-    'lib',
-    '_internal',
-    'vm_platform_strong_product.dill',
-  );
+  String get vmPlatformProductDill {
+    final dillPath = p.absolute(
+      sdkPath,
+      'lib',
+      '_internal',
+      'vm_platform_strong_product.dill',
+    );
+    if (_fileSystem.file(dillPath).existsSync()) {
+      return dillPath;
+    }
+    // In newer SDKs, `vm_platform_strong_product.dill` is replaced with
+    // `vm_platform_product.dill`.
+    return p.absolute(sdkPath, 'lib', '_internal', 'vm_platform_product.dill');
+  }
 
   /// The version when cross-compilation was introduced.
   static final Version _crossCompilationVersion = Version.parse('3.8.0');

--- a/apps/distroless/dart/test/test-docker.sh
+++ b/apps/distroless/dart/test/test-docker.sh
@@ -19,6 +19,9 @@ echo "DART_VERSION: $DART_VERSION"
 DART="$DART_HOME/bin/dartaotruntime"
 FE_SNAPSHOT="$DART_HOME/bin/snapshots/frontend_server_aot.dart.snapshot"
 VM_PLATFORM="$DART_HOME/lib/_internal/vm_platform_strong_product.dill"
+if [ ! -f "$DART" ]; then
+  VM_PLATFORM="$DART_HOME/lib/_internal/vm_platform_product.dill"
+fi
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 


### PR DESCRIPTION
The latest Dart SDKs have renamed `vm_platform_strong` to `vm_platform`.