### PR TITLE
fix(cli): Always halt when seraching for pubspec.yaml

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 - feat: Allow overriding client environment with Dart define
+- fix: Searching parent directories for a `pubspec.yaml` file always halts now
 - chore: Update dependencies
 
 ## 1.0.13

--- a/apps/cli/lib/src/init/project_init.dart
+++ b/apps/cli/lib/src/init/project_init.dart
@@ -185,7 +185,7 @@ base mixin Configure on CelestCommand {
     } else {
       // For other commands, search recursively for the Celest pubspec file.
       while (!pubspecFile.existsSync()) {
-        if (currentDir == currentDir.parent) {
+        if (fileSystem.identicalSync(currentDir.path, currentDir.parent.path)) {
           _throwNoProject();
         }
         currentDir = currentDir.parent;

--- a/apps/cli/test/init/project_init_test.dart
+++ b/apps/cli/test/init/project_init_test.dart
@@ -1,0 +1,54 @@
+import 'package:celest_cli/src/commands/celest_command.dart';
+import 'package:celest_cli/src/context.dart';
+import 'package:celest_cli/src/exceptions.dart';
+import 'package:celest_cli/src/init/project_init.dart';
+import 'package:mason_logger/src/mason_logger.dart';
+import 'package:test/test.dart';
+
+final class TestCommand extends CelestCommand with Configure {
+  @override
+  String get name => 'test';
+
+  @override
+  String get description => 'test';
+
+  @override
+  Progress? currentProgress;
+
+  @override
+  // ignore: must_call_super
+  Future<int> run() async {
+    await configure();
+    return 0;
+  }
+}
+
+void main() {
+  group('init', () {
+    test('throws when no project found', () async {
+      final projectRoot = await fileSystem.systemTempDirectory.createTemp(
+        'test_project_',
+      );
+      fileSystem.currentDirectory = projectRoot;
+
+      addTearDown(() async {
+        try {
+          await projectRoot.delete(recursive: true);
+        } on Object {
+          // OK
+        }
+      });
+
+      await expectLater(
+        () => TestCommand().run(),
+        throwsA(
+          isA<CliException>().having(
+            (e) => e.message,
+            'message',
+            contains('No Celest project found in the current directory'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
The `==` for directory objects doesn't succeed leading to an infinite loop when reaching the root directory.