### PR TITLE
fix(cli): Only cross-compile with non-Flutter SDKs

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - feat: Allow overriding client environment with Dart define
 - fix: Searching parent directories for a `pubspec.yaml` file always halts now
+- fix: Only cross-compile with non-Flutter Dart SDKs
 - chore: Update dependencies
 
 ## 1.0.13

--- a/apps/cli/lib/src/sdk/dart_sdk.dart
+++ b/apps/cli/lib/src/sdk/dart_sdk.dart
@@ -251,7 +251,10 @@ class Sdk {
 
   /// Whether or not the current SDK supports cross-compilation.
   bool get supportsCrossCompilation {
-    return version >= _crossCompilationVersion;
+    return version >= _crossCompilationVersion &&
+        // TODO(dnys1): The version of `dart` bundled with the Flutter SDK leads
+        //  to VM snapshot errors when cross-compiling, so we don't support it.
+        sdkType == SdkType.dart;
   }
 }
 


### PR DESCRIPTION
There seems to be an issue with the Dart SDK shipped with the latest Flutter betas where cross-compiling results in a VM snapshot error.