### PR TITLE
release(cli): v1.0.14

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 1.0.14
 
 - feat: Allow overriding client environment with Dart define
 - fix: Searching parent directories for a `pubspec.yaml` file always halts now

--- a/apps/cli/fixtures/standalone/api/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/api/goldens/ast.json
@@ -33809,10 +33809,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -33821,7 +33821,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/api/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/api/goldens/ast.resolved.json
@@ -3612,10 +3612,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -3624,7 +3624,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/api/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/api/goldens/celest.json
@@ -3394,8 +3394,8 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 13,
-      "canonicalizedVersion": "1.0.13"
+      "patch": 14,
+      "canonicalizedVersion": "1.0.14"
     },
     "dart": {
       "type": "DART",
@@ -3403,7 +3403,12 @@
         "major": 3,
         "minor": 9,
         "patch": 0,
-        "canonicalizedVersion": "3.9.0"
+        "preRelease": [
+          333.0,
+          2.0,
+          "beta"
+        ],
+        "canonicalizedVersion": "3.9.0-333.2.beta"
       }
     },
     "flutter": {
@@ -3411,8 +3416,13 @@
       "version": {
         "major": 3,
         "minor": 35,
-        "patch": 1,
-        "canonicalizedVersion": "3.35.1"
+        "patch": 0,
+        "preRelease": [
+          0.0,
+          1.0,
+          "pre"
+        ],
+        "canonicalizedVersion": "3.35.0-0.1.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/auth/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/ast.json
@@ -2161,10 +2161,10 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -2173,7 +2173,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/auth/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/ast.resolved.json
@@ -649,10 +649,10 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -661,7 +661,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/auth/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/auth/goldens/celest.json
@@ -652,8 +652,8 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 13,
-      "canonicalizedVersion": "1.0.13"
+      "patch": 14,
+      "canonicalizedVersion": "1.0.14"
     },
     "dart": {
       "type": "DART",
@@ -661,7 +661,12 @@
         "major": 3,
         "minor": 9,
         "patch": 0,
-        "canonicalizedVersion": "3.9.0"
+        "preRelease": [
+          333.0,
+          2.0,
+          "beta"
+        ],
+        "canonicalizedVersion": "3.9.0-333.2.beta"
       }
     },
     "flutter": {
@@ -669,8 +674,13 @@
       "version": {
         "major": 3,
         "minor": 35,
-        "patch": 1,
-        "canonicalizedVersion": "3.35.1"
+        "patch": 0,
+        "preRelease": [
+          0.0,
+          1.0,
+          "pre"
+        ],
+        "canonicalizedVersion": "3.35.0-0.1.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/data/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/data/goldens/ast.json
@@ -728,10 +728,10 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -740,7 +740,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/data/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/data/goldens/ast.resolved.json
@@ -259,10 +259,10 @@
     }
   },
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -271,7 +271,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/data/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/data/goldens/celest.json
@@ -243,8 +243,8 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 13,
-      "canonicalizedVersion": "1.0.13"
+      "patch": 14,
+      "canonicalizedVersion": "1.0.14"
     },
     "dart": {
       "type": "DART",
@@ -252,7 +252,12 @@
         "major": 3,
         "minor": 9,
         "patch": 0,
-        "canonicalizedVersion": "3.9.0"
+        "preRelease": [
+          333.0,
+          2.0,
+          "beta"
+        ],
+        "canonicalizedVersion": "3.9.0-333.2.beta"
       }
     },
     "flutter": {
@@ -260,8 +265,13 @@
       "version": {
         "major": 3,
         "minor": 35,
-        "patch": 1,
-        "canonicalizedVersion": "3.35.1"
+        "patch": 0,
+        "preRelease": [
+          0.0,
+          1.0,
+          "pre"
+        ],
+        "canonicalizedVersion": "3.35.0-0.1.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/env_vars/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/ast.json
@@ -833,10 +833,10 @@
   ],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -845,7 +845,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/env_vars/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/ast.resolved.json
@@ -91,10 +91,10 @@
   ],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -103,7 +103,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/env_vars/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/env_vars/goldens/celest.json
@@ -95,8 +95,8 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 13,
-      "canonicalizedVersion": "1.0.13"
+      "patch": 14,
+      "canonicalizedVersion": "1.0.14"
     },
     "dart": {
       "type": "DART",
@@ -104,7 +104,12 @@
         "major": 3,
         "minor": 9,
         "patch": 0,
-        "canonicalizedVersion": "3.9.0"
+        "preRelease": [
+          333.0,
+          2.0,
+          "beta"
+        ],
+        "canonicalizedVersion": "3.9.0-333.2.beta"
       }
     },
     "flutter": {
@@ -112,8 +117,13 @@
       "version": {
         "major": 3,
         "minor": 35,
-        "patch": 1,
-        "canonicalizedVersion": "3.35.1"
+        "patch": 0,
+        "preRelease": [
+          0.0,
+          1.0,
+          "pre"
+        ],
+        "canonicalizedVersion": "3.35.0-0.1.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/exceptions/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/ast.json
@@ -1331,10 +1331,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -1343,7 +1343,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/exceptions/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/ast.resolved.json
@@ -187,10 +187,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -199,7 +199,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/exceptions/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/exceptions/goldens/celest.json
@@ -179,8 +179,8 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 13,
-      "canonicalizedVersion": "1.0.13"
+      "patch": 14,
+      "canonicalizedVersion": "1.0.14"
     },
     "dart": {
       "type": "DART",
@@ -188,7 +188,12 @@
         "major": 3,
         "minor": 9,
         "patch": 0,
-        "canonicalizedVersion": "3.9.0"
+        "preRelease": [
+          333.0,
+          2.0,
+          "beta"
+        ],
+        "canonicalizedVersion": "3.9.0-333.2.beta"
       }
     },
     "flutter": {
@@ -196,8 +201,13 @@
       "version": {
         "major": 3,
         "minor": 35,
-        "patch": 1,
-        "canonicalizedVersion": "3.35.1"
+        "patch": 0,
+        "preRelease": [
+          0.0,
+          1.0,
+          "pre"
+        ],
+        "canonicalizedVersion": "3.35.0-0.1.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/flutter/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/ast.json
@@ -1105,10 +1105,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "flutter",
@@ -1117,7 +1117,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/flutter/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/ast.resolved.json
@@ -86,10 +86,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "flutter",
@@ -98,7 +98,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/flutter/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/flutter/goldens/celest.json
@@ -84,8 +84,8 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 13,
-      "canonicalizedVersion": "1.0.13"
+      "patch": 14,
+      "canonicalizedVersion": "1.0.14"
     },
     "dart": {
       "type": "DART",
@@ -93,7 +93,12 @@
         "major": 3,
         "minor": 9,
         "patch": 0,
-        "canonicalizedVersion": "3.9.0"
+        "preRelease": [
+          333.0,
+          2.0,
+          "beta"
+        ],
+        "canonicalizedVersion": "3.9.0-333.2.beta"
       }
     },
     "flutter": {
@@ -101,8 +106,13 @@
       "version": {
         "major": 3,
         "minor": 35,
-        "patch": 1,
-        "canonicalizedVersion": "3.35.1"
+        "patch": 0,
+        "preRelease": [
+          0.0,
+          1.0,
+          "pre"
+        ],
+        "canonicalizedVersion": "3.35.0-0.1.pre"
       }
     },
     "targetSdk": "FLUTTER",

--- a/apps/cli/fixtures/standalone/http/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/http/goldens/ast.json
@@ -4963,10 +4963,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -4975,7 +4975,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/http/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/http/goldens/ast.resolved.json
@@ -251,10 +251,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -263,7 +263,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/http/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/http/goldens/celest.json
@@ -240,8 +240,8 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 13,
-      "canonicalizedVersion": "1.0.13"
+      "patch": 14,
+      "canonicalizedVersion": "1.0.14"
     },
     "dart": {
       "type": "DART",
@@ -249,7 +249,12 @@
         "major": 3,
         "minor": 9,
         "patch": 0,
-        "canonicalizedVersion": "3.9.0"
+        "preRelease": [
+          333.0,
+          2.0,
+          "beta"
+        ],
+        "canonicalizedVersion": "3.9.0-333.2.beta"
       }
     },
     "flutter": {
@@ -257,8 +262,13 @@
       "version": {
         "major": 3,
         "minor": 35,
-        "patch": 1,
-        "canonicalizedVersion": "3.35.1"
+        "patch": 0,
+        "preRelease": [
+          0.0,
+          1.0,
+          "pre"
+        ],
+        "canonicalizedVersion": "3.35.0-0.1.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/marcelo/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/ast.json
@@ -1629,10 +1629,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -1641,7 +1641,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/marcelo/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/ast.resolved.json
@@ -230,10 +230,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -242,7 +242,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/marcelo/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/marcelo/goldens/celest.json
@@ -219,8 +219,8 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 13,
-      "canonicalizedVersion": "1.0.13"
+      "patch": 14,
+      "canonicalizedVersion": "1.0.14"
     },
     "dart": {
       "type": "DART",
@@ -228,7 +228,12 @@
         "major": 3,
         "minor": 9,
         "patch": 0,
-        "canonicalizedVersion": "3.9.0"
+        "preRelease": [
+          333.0,
+          2.0,
+          "beta"
+        ],
+        "canonicalizedVersion": "3.9.0-333.2.beta"
       }
     },
     "flutter": {
@@ -236,8 +241,13 @@
       "version": {
         "major": 3,
         "minor": 35,
-        "patch": 1,
-        "canonicalizedVersion": "3.35.1"
+        "patch": 0,
+        "preRelease": [
+          0.0,
+          1.0,
+          "pre"
+        ],
+        "canonicalizedVersion": "3.35.0-0.1.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/fixtures/standalone/streaming/goldens/ast.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/ast.json
@@ -531,10 +531,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -543,7 +543,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   },

--- a/apps/cli/fixtures/standalone/streaming/goldens/ast.resolved.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/ast.resolved.json
@@ -86,10 +86,10 @@
   "secrets": [],
   "databases": {},
   "sdkConfig": {
-    "celest": "1.0.13",
+    "celest": "1.0.14",
     "dart": {
       "type": "dart",
-      "version": "3.9.0",
+      "version": "3.9.0-333.2.beta",
       "enabledExperiments": []
     },
     "targetSdk": "dart",
@@ -98,7 +98,7 @@
     ],
     "flutter": {
       "type": "flutter",
-      "version": "3.35.1",
+      "version": "3.35.0-0.1.pre",
       "enabledExperiments": []
     }
   }

--- a/apps/cli/fixtures/standalone/streaming/goldens/celest.json
+++ b/apps/cli/fixtures/standalone/streaming/goldens/celest.json
@@ -82,8 +82,8 @@
     "celest": {
       "major": 1,
       "minor": 0,
-      "patch": 13,
-      "canonicalizedVersion": "1.0.13"
+      "patch": 14,
+      "canonicalizedVersion": "1.0.14"
     },
     "dart": {
       "type": "DART",
@@ -91,7 +91,12 @@
         "major": 3,
         "minor": 9,
         "patch": 0,
-        "canonicalizedVersion": "3.9.0"
+        "preRelease": [
+          333.0,
+          2.0,
+          "beta"
+        ],
+        "canonicalizedVersion": "3.9.0-333.2.beta"
       }
     },
     "flutter": {
@@ -99,8 +104,13 @@
       "version": {
         "major": 3,
         "minor": 35,
-        "patch": 1,
-        "canonicalizedVersion": "3.35.1"
+        "patch": 0,
+        "preRelease": [
+          0.0,
+          1.0,
+          "pre"
+        ],
+        "canonicalizedVersion": "3.35.0-0.1.pre"
       }
     },
     "targetSdk": "DART",

--- a/apps/cli/lib/src/version.dart
+++ b/apps/cli/lib/src/version.dart
@@ -1,7 +1,7 @@
 import 'package:celest_cli/src/utils/run.dart';
 import 'package:pub_semver/pub_semver.dart';
 
-const String _version = '1.0.13';
+const String _version = '1.0.14';
 
 final String packageVersion = run(() {
   const override = String.fromEnvironment('celest.version');

--- a/apps/cli/pubspec.yaml
+++ b/apps/cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: celest_cli
 description: The command-line interface for Celest.
-version: 1.0.13
+version: 1.0.14
 homepage: https://celest.dev
 repository: https://github.com/celest-dev/celest/tree/main/apps/cli
 


### PR DESCRIPTION
- feat: Allow overriding client environment with Dart define
- fix: Searching parent directories for a `pubspec.yaml` file always halts now
- fix: Only cross-compile with non-Flutter Dart SDKs
- chore: Use new Flutter version file
- chore: Update dependencies