### PR TITLE
fix(cli): Improve reload handling

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+- fix: Improved reload handling
+
 ## 1.0.14
 
 - feat: Allow overriding client environment with Dart define

--- a/apps/cli/lib/src/frontend/celest_frontend.dart
+++ b/apps/cli/lib/src/frontend/celest_frontend.dart
@@ -391,10 +391,14 @@ final class CelestFrontend with CloudRepository {
                     )).port,
               );
             } on CompilationException catch (e, st) {
+              currentProgress!.fail();
               cliLogger.err(
                 'Project has errors. Please fix them and save the '
                 'corresponding files.',
               );
+              for (final compilerLine in e.compilerOutput) {
+                cliLogger.err(compilerLine);
+              }
               performance.captureError(e, stackTrace: st);
               break;
             }
@@ -453,8 +457,8 @@ final class CelestFrontend with CloudRepository {
         // there is one.
         final exitCode = await Future.any<int?>([
           _nextChangeSet().then((_) => null),
-          if (childProcess case final childProcess?)
-            Future.value(childProcess.exitCode),
+          if (childProcess case final childProcess? when childProcess.isStarted)
+            childProcess.exitCode,
         ]);
         if (exitCode != null) {
           return exitCode;


### PR DESCRIPTION
- When compilation errors are flagged, accept the result from the frontend server so that we can call `compile` again
- Reload all isolates when performing a hot reload